### PR TITLE
Tab Bottom Border Fix + Region Names

### DIFF
--- a/TECApp/src/api/requests.ts
+++ b/TECApp/src/api/requests.ts
@@ -1,6 +1,6 @@
-const url = process.env.EXPO_PUBLIC_BACKEND_URL;
+const url = process.env.EXPO_PUBLIC_BACKEND_URL
 
-export async function getAll(){
-    const response = await fetch(url, {method: "GET"});
-    return await response.text();
+export async function getAll() {
+  const response = await fetch(url, { method: 'GET' })
+  return await response.text()
 }

--- a/TECApp/src/components/DataVisualizations.tsx
+++ b/TECApp/src/components/DataVisualizations.tsx
@@ -1,15 +1,16 @@
-import React from 'react';
-import { Text, StyleSheet, View } from 'react-native';
+import React from 'react'
+import { Text, StyleSheet, View } from 'react-native'
 
 const DataVisualizations = () => {
   return (
     <View style={styles.container}>
       <Text style={styles.text}>
-        Here you can view data visualizations related to the selected country's renewable energy sources.
+        Here you can view data visualizations related to the selected country's
+        renewable energy sources.
       </Text>
     </View>
-  );
-};
+  )
+}
 
 const styles = StyleSheet.create({
   container: {
@@ -22,6 +23,6 @@ const styles = StyleSheet.create({
     fontWeight: '400',
     fontSize: 14,
   },
-});
+})
 
-export default DataVisualizations;
+export default DataVisualizations

--- a/TECApp/src/components/DistributeRenewables.tsx
+++ b/TECApp/src/components/DistributeRenewables.tsx
@@ -1,15 +1,17 @@
-import React from 'react';
-import { Text, StyleSheet, View } from 'react-native';
+import React from 'react'
+import { Text, StyleSheet, View } from 'react-native'
 
 const DistributeRenewables = () => {
   return (
     <View style={styles.container}>
       <Text style={styles.text}>
-        Using the sliders below, make region specific changes for each renewable energy source to reach 12 TW of renewable capacity. This will override default values set in the global dashboard.
+        Using the sliders below, make region specific changes for each renewable
+        energy source to reach 12 TW of renewable capacity. This will override
+        default values set in the global dashboard.
       </Text>
     </View>
-  );
-};
+  )
+}
 
 const styles = StyleSheet.create({
   container: {
@@ -22,6 +24,6 @@ const styles = StyleSheet.create({
     fontWeight: '400',
     fontSize: 14,
   },
-});
+})
 
-export default DistributeRenewables;
+export default DistributeRenewables

--- a/TECApp/src/components/RegionBottomSheet.tsx
+++ b/TECApp/src/components/RegionBottomSheet.tsx
@@ -10,7 +10,7 @@ export interface RegionBottomSheetProps {
 }
 
 const RegionBottomSheet = ({ selectedRegion }: RegionBottomSheetProps) => {
-  const snapPoints = useMemo(() => ['10%', '25%', '50%'], [])
+  const snapPoints = useMemo(() => ['10%', '25%', '50%', '80%'], [])
   const bottomSheetRef = useRef<BottomSheet>(null)
   const [activeTab, setActiveTab] = useState<'renewables' | 'visualizations'>(
     'renewables',

--- a/TECApp/src/components/RegionBottomSheet.tsx
+++ b/TECApp/src/components/RegionBottomSheet.tsx
@@ -3,6 +3,7 @@ import { Text, View, StyleSheet, TouchableOpacity } from 'react-native'
 import BottomSheet from '@gorhom/bottom-sheet'
 import DistributeRenewables from './DistributeRenewables'
 import DataVisualizations from './DataVisualizations'
+import { TextInput } from 'react-native-gesture-handler'
 
 export interface RegionBottomSheetProps {
   selectedRegion: string
@@ -29,31 +30,45 @@ const RegionBottomSheet = ({ selectedRegion }: RegionBottomSheetProps) => {
             <Text style={styles.regionName}>{selectedRegion}</Text>
             <View style={styles.tabContainer}>
               <TouchableOpacity onPress={() => setActiveTab('renewables')}>
-                <Text
+                <View
                   style={
                     activeTab === 'renewables'
-                      ? styles.activeTab
-                      : styles.inactiveTab
+                      ? styles.activeTabWrapper
+                      : styles.inactiveTabWrapper
                   }
                 >
-                  Distribute Renewables
-                </Text>
+                  <Text
+                    style={
+                      activeTab === 'renewables'
+                        ? styles.activeTab
+                        : styles.inactiveTab
+                    }
+                  >
+                    Distribute Renewables
+                  </Text>
+                </View>
               </TouchableOpacity>
               <TouchableOpacity onPress={() => setActiveTab('visualizations')}>
-                <Text
+                <View
                   style={
                     activeTab === 'visualizations'
-                      ? styles.activeTab
-                      : styles.inactiveTab
+                      ? styles.activeTabWrapper
+                      : styles.inactiveTabWrapper
                   }
                 >
-                  Data Visualizations
-                </Text>
+                  <Text
+                    style={
+                      activeTab === 'visualizations'
+                        ? styles.activeTab
+                        : styles.inactiveTab
+                    }
+                  >
+                    Data Visualizations
+                  </Text>
+                </View>
               </TouchableOpacity>
             </View>
-            <View style={styles.horizontalLineContainer}>
-              <View style={styles.horizontalLine} />
-            </View>
+            <View style={styles.horizontalLine} />
             {activeTab === 'renewables' ? (
               <DistributeRenewables />
             ) : (
@@ -78,7 +93,6 @@ const styles = StyleSheet.create({
   regionInfoContainer: {
     flex: 1,
     width: '100%',
-    padding: 16,
     alignItems: 'flex-start',
   },
   regionName: {
@@ -86,31 +100,35 @@ const styles = StyleSheet.create({
     fontSize: 28,
     fontFamily: 'Brix Sans',
     fontWeight: '400',
+    paddingBottom: 10,
   },
   tabContainer: {
     flexDirection: 'row',
     marginTop: 8,
     gap: 43,
   },
-  horizontalLineContainer: {
+  horizontalLine: {
     width: '95%',
     height: 1,
     backgroundColor: '#ccc',
   },
-  horizontalLine: {
-    width: '95%',
-    height: 1,
-    backgroundColor: '#ccc'
-  },
   activeTab: {
-    fontWeight: '700',
+    fontWeight: '400',
     color: '#266297',
-    borderBottomWidth: 2,
-    borderBottomColor: '#007BFF',
+    fontSize: 16,
+    paddingBottom: 4,
   },
   inactiveTab: {
     color: '#000',
     fontWeight: '400',
+    fontSize: 16,
+  },
+  activeTabWrapper: {
+    borderBottomWidth: 2,
+    borderBottomColor: '#266297',
+  },
+  inactiveTabWrapper: {
+    borderBottomWidth: 0,
   },
   text: {
     fontSize: 14,

--- a/TECApp/src/components/WorldMap.tsx
+++ b/TECApp/src/components/WorldMap.tsx
@@ -1,5 +1,5 @@
 import * as d3 from 'd3'
-import React, {useEffect, useState} from 'react'
+import React, { useEffect, useState } from 'react'
 import { StyleSheet, Dimensions, Platform } from 'react-native'
 import data from '../../GeoChart.world.geo.json'
 import Svg, { Path, G } from 'react-native-svg'
@@ -35,6 +35,18 @@ export const WorldMap = ({ onSelectCountry }: WorldMapProps) => {
     OPA: '#A86937',
   }
 
+  const regionMap = {
+    NAM: 'North America',
+    LAM: 'Latin America',
+    SSA: 'Sub-Saharan Africa',
+    MEA: 'Middle East & North Africa',
+    EUR: 'Europe',
+    NEE: 'North East Eurasia',
+    IND: 'Indian Subcontinent',
+    CHN: 'Greater China',
+    SEA: 'South East Asia',
+    OPA: 'OECD Pacific',
+  }
 
   return (
     <ReactNativeZoomableView
@@ -61,10 +73,10 @@ export const WorldMap = ({ onSelectCountry }: WorldMapProps) => {
               //@ts-expect-error: to allow clicking to work on web
               onClick={() => {
                 //onSelectCountry here rather than alert
-                onSelectCountry(feature.properties.region)
+                onSelectCountry(regionMap[feature.properties.region])
               }}
               onPress={() => {
-                onSelectCountry(feature.properties.region)
+                onSelectCountry(regionMap[feature.properties.region])
               }}
             ></Path>
           ))}

--- a/TECApp/src/pages/Home.tsx
+++ b/TECApp/src/pages/Home.tsx
@@ -13,19 +13,19 @@ export const Home = () => {
   const [selectedRegion, setSelectedRegion] = useState<string | null>(null)
 
   const handleRegionSelect = (region: string) => {
-    setSelectedRegion(region);
+    setSelectedRegion(region)
   }
 
   return (
     <View style={mobileStyles.appWrapper}>
       <GestureHandlerRootView style={mobileStyles.gestureHandler}>
-      <WelcomePopup />
-      <WorldMap onSelectCountry={handleRegionSelect}/>
-      <RegionBottomSheet selectedRegion={selectedRegion ?? ''} />
-      <View style={mobileStyles.trackerWrapper}>
-        <Tracker type="temperature" />
-        <Tracker type="renewable" />
-      </View>
+        <WelcomePopup />
+        <WorldMap onSelectCountry={handleRegionSelect} />
+        <RegionBottomSheet selectedRegion={selectedRegion ?? ''} />
+        <View style={mobileStyles.trackerWrapper}>
+          <Tracker type="temperature" />
+          <Tracker type="renewable" />
+        </View>
       </GestureHandlerRootView>
     </View>
   )


### PR DESCRIPTION
Resolves #31 

Quick stylistic fixes for the bottom sheet; added blue bottom borders for the tabs when they're active and changed region names from acronyms to full names. Also moved padding around a little bit to match Figma.
<img width="407" alt="Screenshot 2024-07-16 at 4 42 00 PM" src="https://github.com/user-attachments/assets/bcb65420-4b49-4cb7-adf9-ae562a2c38c5">
