### PR TITLE
Dynamic Axes (Mike's Request)

### DIFF
--- a/TECApp/src/components/DataVisualizations/BAUComparison.tsx
+++ b/TECApp/src/components/DataVisualizations/BAUComparison.tsx
@@ -12,14 +12,13 @@ const graphWidth = vw * 0.8
 const leftMargin = 60
 
 const dummyBAU = [
-  { year: 2024, value: Math.random() * 12 + 4 },
-  { year: 2025, value: Math.random() * 12 + 4 },
-  { year: 2026, value: Math.random() * 12 + 4 },
-  { year: 2027, value: Math.random() * 12 + 4 },
-  { year: 2028, value: Math.random() * 12 + 4 },
-  { year: 2029, value: Math.random() * 12 + 4 },
-  { year: 2030, value: Math.random() * 12 + 4 },
-]
+  { year: 2024, value: 10},
+  { year: 2025, value: 12 },
+  { year: 2026, value: 14 },
+  { year: 2027, value: 9 },
+  { year: 2028, value: 11.5 },
+  { year: 2029, value: 13 },
+  { year: 2030, value: 15},]
 const dummyAltered = [
   { year: 2024, value: Math.random() * 12 + 4 },
   { year: 2025, value: Math.random() * 12 + 4 },
@@ -66,19 +65,19 @@ export const BAUComparison = ({ region }: BAUComparisonProps) => {
     .x((d) => x(d.year))
     .y1((d) => y(d.value))
     .y0(graphHeight + offset)
-    .curve(d3.curveBumpX)(dummyBAU)
+    .curve(d3.curveMonotoneX)(dummyBAU)
 
   const BAU_curve = d3
     .line<DataPoint>()
     .x((d) => x(d.year))
     .y((d) => y(d.value))
-    .curve(d3.curveBumpX)(dummyBAU)
+    .curve(d3.curveMonotoneX)(dummyBAU)
 
   const altered_curve = d3
     .line<DataPoint>()
     .x((d) => x(d.year))
     .y((d) => y(d.value))
-    .curve(d3.curveBumpX)(dummyAltered)
+    .curve(d3.curveMonotoneX)(dummyAltered)
 
   return (
     <View style={{ width: '100%' }}>

--- a/TECApp/src/components/DataVisualizations/BAUComparison.tsx
+++ b/TECApp/src/components/DataVisualizations/BAUComparison.tsx
@@ -12,25 +12,31 @@ const graphWidth = vw * 0.8
 const leftMargin = 60
 
 const dummyBAU = [
-  { year: 2024, value:Math.random() * 12 + 4 },
+  { year: 2024, value: Math.random() * 12 + 4 },
   { year: 2026, value: Math.random() * 12 + 4 },
   { year: 2027, value: Math.random() * 12 + 4 },
-  { year: 2028, value:Math.random() * 12 + 4},
-  { year: 2029, value:Math.random() * 12 + 4 },
-  { year: 2030, value:Math.random() * 12 + 4 },
+  { year: 2028, value: Math.random() * 12 + 4 },
+  { year: 2029, value: Math.random() * 12 + 4 },
+  { year: 2030, value: Math.random() * 12 + 4 },
 ]
 const dummyAltered = [
-  { year: 2024, value:Math.random() * 12 + 4},
-  { year: 2025, value:Math.random() * 12 + 4},
-  { year: 2026, value:Math.random() * 12 + 4},
-  { year: 2027, value:Math.random() * 12 + 4 },
+  { year: 2024, value: Math.random() * 12 + 4 },
+  { year: 2025, value: Math.random() * 12 + 4 },
+  { year: 2026, value: Math.random() * 12 + 4 },
+  { year: 2027, value: Math.random() * 12 + 4 },
   { year: 2028, value: Math.random() * 12 + 4 },
   { year: 2029, value: Math.random() * 12 + 4 },
   { year: 2030, value: Math.random() * 12 + 4 },
 ]
 
-const yMin = Math.min(Math.min(...dummyBAU.map(val=>val.value)), Math.min(...dummyAltered.map(val=>val.value)))
-const yMax = Math.max(Math.max(...dummyBAU.map(val=>val.value)), Math.max(...dummyAltered.map(val=>val.value)))
+const yMin = Math.min(
+  Math.min(...dummyBAU.map((val) => val.value)),
+  Math.min(...dummyAltered.map((val) => val.value)),
+)
+const yMax = Math.max(
+  Math.max(...dummyBAU.map((val) => val.value)),
+  Math.max(...dummyAltered.map((val) => val.value)),
+)
 
 const xMin = 2024
 const xMax = 2030
@@ -61,7 +67,7 @@ export const BAUComparison = ({ region }: BAUComparisonProps) => {
     .y0(graphHeight + offset)
     .curve(d3.curveBumpX)(dummyBAU)
 
-    const BAU_curve = d3
+  const BAU_curve = d3
     .line<DataPoint>()
     .x((d) => x(d.year))
     .y((d) => y(d.value))
@@ -92,7 +98,7 @@ export const BAUComparison = ({ region }: BAUComparisonProps) => {
           <LineGraph
             yMin={yMin}
             yMax={yMax}
-            gradient={{curve: BAU_gradient, color: '#9ED7F5'}}
+            gradient={{ curve: BAU_gradient, color: '#9ED7F5' }}
             gradientCurve={{ curve: BAU_curve, color: '#9ED7F5' }}
             lineCurves={[{ curve: altered_curve, color: '#C66AAA' }]}
           />

--- a/TECApp/src/components/DataVisualizations/BAUComparison.tsx
+++ b/TECApp/src/components/DataVisualizations/BAUComparison.tsx
@@ -12,26 +12,25 @@ const graphWidth = vw * 0.8
 const leftMargin = 60
 
 const dummyBAU = [
-  { year: 2024, value: Math.random() * 12 + 4 },
-  { year: 2025, value: Math.random() * 12 + 4 },
+  { year: 2024, value:Math.random() * 12 + 4 },
   { year: 2026, value: Math.random() * 12 + 4 },
   { year: 2027, value: Math.random() * 12 + 4 },
-  { year: 2028, value: Math.random() * 12 + 4 },
-  { year: 2029, value: Math.random() * 12 + 4 },
-  { year: 2030, value: Math.random() * 12 + 4 },
+  { year: 2028, value:Math.random() * 12 + 4},
+  { year: 2029, value:Math.random() * 12 + 4 },
+  { year: 2030, value:Math.random() * 12 + 4 },
 ]
 const dummyAltered = [
-  { year: 2024, value: Math.random() * 12 + 4 },
-  { year: 2025, value: Math.random() * 12 + 4 },
-  { year: 2026, value: Math.random() * 12 + 4 },
-  { year: 2027, value: Math.random() * 12 + 4 },
+  { year: 2024, value:Math.random() * 12 + 4},
+  { year: 2025, value:Math.random() * 12 + 4},
+  { year: 2026, value:Math.random() * 12 + 4},
+  { year: 2027, value:Math.random() * 12 + 4 },
   { year: 2028, value: Math.random() * 12 + 4 },
   { year: 2029, value: Math.random() * 12 + 4 },
   { year: 2030, value: Math.random() * 12 + 4 },
 ]
 
-const yMin = 0
-const yMax = 20
+const yMin = Math.min(Math.min(...dummyBAU.map(val=>val.value)), Math.min(...dummyAltered.map(val=>val.value)))
+const yMax = Math.max(Math.max(...dummyBAU.map(val=>val.value)), Math.max(...dummyAltered.map(val=>val.value)))
 
 const xMin = 2024
 const xMax = 2030
@@ -55,18 +54,24 @@ export const BAUComparison = ({ region }: BAUComparisonProps) => {
     .domain([xMin, xMax])
     .range([leftMargin, graphWidth])
 
-  const BAU_curve = d3
+  const BAU_gradient = d3
     .area<DataPoint>()
     .x((d) => x(d.year))
     .y1((d) => y(d.value))
     .y0(graphHeight + offset)
-    .curve(d3.curveNatural)(dummyBAU)
+    .curve(d3.curveBumpX)(dummyBAU)
+
+    const BAU_curve = d3
+    .line<DataPoint>()
+    .x((d) => x(d.year))
+    .y((d) => y(d.value))
+    .curve(d3.curveBumpX)(dummyBAU)
 
   const altered_curve = d3
     .line<DataPoint>()
     .x((d) => x(d.year))
     .y((d) => y(d.value))
-    .curve(d3.curveNatural)(dummyAltered)
+    .curve(d3.curveBumpX)(dummyAltered)
 
   return (
     <View style={{ width: '100%' }}>
@@ -85,6 +90,9 @@ export const BAUComparison = ({ region }: BAUComparisonProps) => {
           <GraphKey label="ALTERED RENEWABLES" color="#C66AAA" />
           <GraphKey label="BUSINESS-AS-USUAL" color="#58C4D4" />
           <LineGraph
+            yMin={yMin}
+            yMax={yMax}
+            gradient={{curve: BAU_gradient, color: '#9ED7F5'}}
             gradientCurve={{ curve: BAU_curve, color: '#9ED7F5' }}
             lineCurves={[{ curve: altered_curve, color: '#C66AAA' }]}
           />

--- a/TECApp/src/components/DataVisualizations/BAUComparison.tsx
+++ b/TECApp/src/components/DataVisualizations/BAUComparison.tsx
@@ -13,6 +13,7 @@ const leftMargin = 60
 
 const dummyBAU = [
   { year: 2024, value: Math.random() * 12 + 4 },
+  { year: 2025, value: Math.random() * 12 + 4 },
   { year: 2026, value: Math.random() * 12 + 4 },
   { year: 2027, value: Math.random() * 12 + 4 },
   { year: 2028, value: Math.random() * 12 + 4 },

--- a/TECApp/src/components/DataVisualizations/LineGraph.tsx
+++ b/TECApp/src/components/DataVisualizations/LineGraph.tsx
@@ -18,8 +18,6 @@ const offset = 20
 const graphWidth = vw * 0.8
 const leftMargin = 60
 
-const verticalAxis = [0, 4, 8, 12, 16, 20]
-const horizontalAxis = [2024, 2026, 2028, 2030]
 
 export type CurveObject = {
   color: string
@@ -28,16 +26,24 @@ export type CurveObject = {
 }
 
 type LineGraphProps = {
+  gradient: CurveObject,
   gradientCurve: CurveObject
   lineCurves: CurveObject[]
+  yMin: number,
+  yMax: number,
 }
 
-export const LineGraph = ({ gradientCurve, lineCurves }: LineGraphProps) => {
+export const LineGraph = ({ gradient, gradientCurve, lineCurves, yMin, yMax }: LineGraphProps) => {
+  const yRange = yMax-yMin;
+
+  const verticalAxis = [yMin, yMin+yRange*0.2, yMin+yRange*0.4, yMin+yRange*0.6, yMin+yRange*0.8, yMax]
+  const horizontalAxis = [2024, 2026, 2028, 2030]
+
   return (
     <Svg width={graphWidth} height={svgHeight}>
       <Defs>
         <LinearGradient id="grad" x1="0" y1="0" x2="0" y2="1">
-          <Stop offset="0" stopColor={gradientCurve.color} stopOpacity={0.8} />
+          <Stop offset="0" stopColor={gradientCurve.color} stopOpacity={0.9} />
           <Stop offset="1" stopColor="#FFF" stopOpacity={0.01} />
         </LinearGradient>
       </Defs>
@@ -50,20 +56,20 @@ export const LineGraph = ({ gradientCurve, lineCurves }: LineGraphProps) => {
               key={key}
               x1={leftMargin}
               x2={graphWidth}
-              y1={graphHeight * (e / 20) + offset}
-              y2={graphHeight * (e / 20) + offset}
+              y1={graphHeight * (e-yMin)/yRange + offset}
+              y2={graphHeight * (e-yMin)/yRange + offset}
               stroke="#E9E9E9"
               strokeWidth={2}
             />
             <TextSvg
               strokeWidth={0.1}
-              y={graphHeight * ((20 - e) / 20) + offset + 3.5}
-              x={e >= 10 ? leftMargin - 22.5 : leftMargin - 17.5}
+              y={graphHeight * ((yMax+yMin)-e-yMin)/yRange + offset + 3.5}
+              x={e >= 10 ? leftMargin - 25 : leftMargin - 20}
               fontSize={10}
               fill="#9E9FA7"
               stroke="#9E9FA7"
             >
-              {e}
+              {e.toFixed(1)}
             </TextSvg>
           </G>
         ))}
@@ -110,10 +116,16 @@ export const LineGraph = ({ gradientCurve, lineCurves }: LineGraphProps) => {
       {/* Graph Curves */}
       <G>
         <Path
+          d={gradient.curve}
+          strokeWidth={0}
+          stroke={gradient.color}
+          fill="url(#grad)"
+        />
+        <Path
           d={gradientCurve.curve}
           strokeWidth={2}
           stroke={gradientCurve.color}
-          fill="url(#grad)"
+          fill="none"
         />
         {lineCurves.map((curveObject, key) => (
           <Path
@@ -124,30 +136,6 @@ export const LineGraph = ({ gradientCurve, lineCurves }: LineGraphProps) => {
             stroke={curveObject.color}
           />
         ))}
-        <Line
-          x1={leftMargin}
-          x2={graphWidth}
-          y1={graphHeight + offset}
-          y2={graphHeight + offset}
-          stroke="#E9E9E9"
-          strokeWidth={2}
-        />
-        <Line
-          x1={leftMargin}
-          x2={leftMargin}
-          y1={graphHeight + offset + 3}
-          y2={0}
-          stroke="#FFF"
-          strokeWidth={2.2}
-        ></Line>
-        <Line
-          x1={graphWidth}
-          x2={graphWidth}
-          y1={graphHeight + offset + 3}
-          y2={0}
-          stroke="#FFF"
-          strokeWidth={2.2}
-        ></Line>
       </G>
     </Svg>
   )

--- a/TECApp/src/components/DataVisualizations/LineGraph.tsx
+++ b/TECApp/src/components/DataVisualizations/LineGraph.tsx
@@ -18,7 +18,6 @@ const offset = 20
 const graphWidth = vw * 0.8
 const leftMargin = 60
 
-
 export type CurveObject = {
   color: string
   curve: string
@@ -26,17 +25,30 @@ export type CurveObject = {
 }
 
 type LineGraphProps = {
-  gradient: CurveObject,
+  gradient: CurveObject
   gradientCurve: CurveObject
   lineCurves: CurveObject[]
-  yMin: number,
-  yMax: number,
+  yMin: number
+  yMax: number
 }
 
-export const LineGraph = ({ gradient, gradientCurve, lineCurves, yMin, yMax }: LineGraphProps) => {
-  const yRange = yMax-yMin;
+export const LineGraph = ({
+  gradient,
+  gradientCurve,
+  lineCurves,
+  yMin,
+  yMax,
+}: LineGraphProps) => {
+  const yRange = yMax - yMin
 
-  const verticalAxis = [yMin, yMin+yRange*0.2, yMin+yRange*0.4, yMin+yRange*0.6, yMin+yRange*0.8, yMax]
+  const verticalAxis = [
+    yMin,
+    yMin + yRange * 0.2,
+    yMin + yRange * 0.4,
+    yMin + yRange * 0.6,
+    yMin + yRange * 0.8,
+    yMax,
+  ]
   const horizontalAxis = [2024, 2026, 2028, 2030]
 
   return (
@@ -56,14 +68,16 @@ export const LineGraph = ({ gradient, gradientCurve, lineCurves, yMin, yMax }: L
               key={key}
               x1={leftMargin}
               x2={graphWidth}
-              y1={graphHeight * (e-yMin)/yRange + offset}
-              y2={graphHeight * (e-yMin)/yRange + offset}
+              y1={(graphHeight * (e - yMin)) / yRange + offset}
+              y2={(graphHeight * (e - yMin)) / yRange + offset}
               stroke="#E9E9E9"
               strokeWidth={2}
             />
             <TextSvg
               strokeWidth={0.1}
-              y={graphHeight * ((yMax+yMin)-e-yMin)/yRange + offset + 3.5}
+              y={
+                (graphHeight * (yMax + yMin - e - yMin)) / yRange + offset + 3.5
+              }
               x={e >= 10 ? leftMargin - 25 : leftMargin - 20}
               fontSize={10}
               fill="#9E9FA7"

--- a/TECApp/src/components/DataVisualizations/RegionalComparison.tsx
+++ b/TECApp/src/components/DataVisualizations/RegionalComparison.tsx
@@ -38,7 +38,7 @@ const leftMargin = 60
 const colorMap = {
   'North America': '#9ED7F5',
   'Latin America': '#78B85D',
-  'Europe': '#0D5BA5',
+  Europe: '#0D5BA5',
   'Sub-Saharan Africa': '#01ABE7',
   'Middle East & N. Africa': '#F8EE88',
   'North East Eurasia': '#E78C68',
@@ -167,10 +167,9 @@ export const RegionalComparison = ({ region }: RegionalComparisonProps) => {
   const [yMin, setYMin] = useState<number>()
   const [yMax, setyMax] = useState<number>()
 
-  const [currGradient, setCurrGradient] = useState<CurveObject>();
-  const [currGradientCurve, setCurrGradientCurve] = useState<CurveObject>();
+  const [currGradient, setCurrGradient] = useState<CurveObject>()
+  const [currGradientCurve, setCurrGradientCurve] = useState<CurveObject>()
   const [currLineCurves, setCurrLineCurves] = useState<CurveObject[]>()
-
 
   const onCheck = (key: number) => {
     if (numSelected < 4 || dropdownOptions[key].selected) {
@@ -191,53 +190,56 @@ export const RegionalComparison = ({ region }: RegionalComparisonProps) => {
   }
 
   useEffect(() => {
-    const selectedRegions = dropdownOptions.filter(item => item.selected)     //regions checked
-    const allVisibleRegions = [...selectedRegions, dropdownOptions.find(item=>item.region===region)] //all curves on graph
-    
+    const selectedRegions = dropdownOptions.filter((item) => item.selected) //regions checked
+    const allVisibleRegions = [
+      ...selectedRegions,
+      dropdownOptions.find((item) => item.region === region),
+    ] //all curves on graph
+
     let yMin = Number.POSITIVE_INFINITY
     let yMax = Number.NEGATIVE_INFINITY
 
-    for(const i of allVisibleRegions){
-      yMin = Math.min(yMin, Math.min(...i.data.map(val=>val.value)))
-      yMax = Math.max(yMax, Math.max(...i.data.map(val=>val.value)))
+    for (const i of allVisibleRegions) {
+      yMin = Math.min(yMin, Math.min(...i.data.map((val) => val.value)))
+      yMax = Math.max(yMax, Math.max(...i.data.map((val) => val.value)))
     }
 
     setYMin(yMin)
     setyMax(yMax)
 
     const y = d3
-    .scaleLinear()
-    .domain([yMin, yMax])
-    .range([graphHeight + offset, offset])
+      .scaleLinear()
+      .domain([yMin, yMax])
+      .range([graphHeight + offset, offset])
     const x = d3
       .scaleLinear()
       .domain([xMin, xMax])
       .range([leftMargin, graphWidth])
 
-      setCurrGradient({
-        color: colorMap[region],
-        curve: d3
-          .area<DataPoint>()
-          .x((d) => x(d.year))
-          .y1((d) => y(d.value))
-          .y0(graphHeight + offset)
-          .curve(d3.curveBumpX)(
-          dropdownOptions.find((item) => item.region === region).data,
-        ),
-        region: region,
-      })
+    setCurrGradient({
+      color: colorMap[region],
+      curve: d3
+        .area<DataPoint>()
+        .x((d) => x(d.year))
+        .y1((d) => y(d.value))
+        .y0(graphHeight + offset)
+        .curve(d3.curveBumpX)(
+        dropdownOptions.find((item) => item.region === region).data,
+      ),
+      region: region,
+    })
 
     setCurrGradientCurve({
-        color: colorMap[region],
-        curve: d3
-          .line<DataPoint>()
-          .x((d) => x(d.year))
-          .y((d) => y(d.value))
-          .curve(d3.curveBumpX)(
-          dropdownOptions.find((item) => item.region === region).data,
-        ),
-        region: region,
-      })
+      color: colorMap[region],
+      curve: d3
+        .line<DataPoint>()
+        .x((d) => x(d.year))
+        .y((d) => y(d.value))
+        .curve(d3.curveBumpX)(
+        dropdownOptions.find((item) => item.region === region).data,
+      ),
+      region: region,
+    })
 
     const lineCurves = []
     for (const i of selectedRegions) {
@@ -252,8 +254,7 @@ export const RegionalComparison = ({ region }: RegionalComparisonProps) => {
       }
       lineCurves.push(curve)
     }
-    setCurrLineCurves(lineCurves)  
-
+    setCurrLineCurves(lineCurves)
   }, [numSelected])
 
   return (

--- a/TECApp/src/components/DataVisualizations/RegionalComparison.tsx
+++ b/TECApp/src/components/DataVisualizations/RegionalComparison.tsx
@@ -38,7 +38,7 @@ const leftMargin = 60
 const colorMap = {
   'North America': '#9ED7F5',
   'Latin America': '#78B85D',
-  Europe: '#0D5BA5',
+  'Europe': '#0D5BA5',
   'Sub-Saharan Africa': '#01ABE7',
   'Middle East & N. Africa': '#F8EE88',
   'North East Eurasia': '#E78C68',
@@ -49,13 +49,13 @@ const colorMap = {
 }
 
 const dummyNAM = [
-  { year: 2024, value: Math.random() * 12 + 4 },
-  { year: 2025, value: Math.random() * 12 + 4 },
-  { year: 2026, value: Math.random() * 12 + 4 },
-  { year: 2027, value: Math.random() * 12 + 4 },
-  { year: 2028, value: Math.random() * 12 + 4 },
-  { year: 2029, value: Math.random() * 12 + 4 },
-  { year: 2030, value: Math.random() * 12 + 4 },
+  { year: 2024, value: 4 },
+  { year: 2025, value: 6 },
+  { year: 2026, value: 5 },
+  { year: 2027, value: 4.8 },
+  { year: 2028, value: 6.2 },
+  { year: 2029, value: 5.8 },
+  { year: 2030, value: 5 },
 ]
 const dummyLAM = [
   { year: 2024, value: Math.random() * 12 + 4 },
@@ -88,13 +88,13 @@ const dummyMEA = [
 ]
 
 const dummySSA = [
-  { year: 2024, value: Math.random() * 12 + 4 },
-  { year: 2025, value: Math.random() * 12 + 4 },
-  { year: 2026, value: Math.random() * 12 + 4 },
-  { year: 2027, value: Math.random() * 12 + 4 },
-  { year: 2028, value: Math.random() * 12 + 4 },
-  { year: 2029, value: Math.random() * 12 + 4 },
-  { year: 2030, value: Math.random() * 12 + 4 },
+  { year: 2024, value: 0.2 },
+  { year: 2025, value: 0.1 },
+  { year: 2026, value: 0.15 },
+  { year: 2027, value: 0.12 },
+  { year: 2028, value: 0.09 },
+  { year: 2029, value: 0.19 },
+  { year: 2030, value: 0.25 },
 ]
 
 const dummyNEE = [
@@ -146,9 +146,6 @@ const dummyOPA = [
   { year: 2030, value: Math.random() * 12 + 4 },
 ]
 
-const yMin = 0
-const yMax = 20
-
 const xMin = 2024
 const xMax = 2030
 
@@ -167,43 +164,13 @@ export const RegionalComparison = ({ region }: RegionalComparisonProps) => {
     { region: 'Indian Subcontinent', selected: false, data: dummyIND },
   ])
   const [numSelected, setNumSelected] = useState<number>(0)
-  const [currLineCurves, setCurrLineCurves] = useState<CurveObject[]>(undefined)
+  const [yMin, setYMin] = useState<number>()
+  const [yMax, setyMax] = useState<number>()
 
-  const y = d3
-    .scaleLinear()
-    .domain([yMin, yMax])
-    .range([graphHeight + offset, offset])
-  const x = d3
-    .scaleLinear()
-    .domain([xMin, xMax])
-    .range([leftMargin, graphWidth])
+  const [currGradient, setCurrGradient] = useState<CurveObject>();
+  const [currGradientCurve, setCurrGradientCurve] = useState<CurveObject>();
+  const [currLineCurves, setCurrLineCurves] = useState<CurveObject[]>()
 
-  const gradientCurve = {
-    color: colorMap[region],
-    curve: d3
-      .area<DataPoint>()
-      .x((d) => x(d.year))
-      .y1((d) => y(d.value))
-      .y0(graphHeight + offset)
-      .curve(d3.curveNatural)(
-      dropdownOptions.find((item) => item.region === region).data,
-    ),
-    region: region,
-  }
-
-  const lineCurves = []
-  for (const i of dropdownOptions.filter((item) => item.region !== region)) {
-    const curve = {
-      color: colorMap[i.region],
-      curve: d3
-        .line<DataPoint>()
-        .x((d) => x(d.year))
-        .y((d) => y(d.value))
-        .curve(d3.curveNatural)(i.data),
-      region: i.region,
-    }
-    lineCurves.push(curve)
-  }
 
   const onCheck = (key: number) => {
     if (numSelected < 4 || dropdownOptions[key].selected) {
@@ -224,18 +191,69 @@ export const RegionalComparison = ({ region }: RegionalComparisonProps) => {
   }
 
   useEffect(() => {
-    const selectedRegions = dropdownOptions.filter((item) => item.selected)
+    const selectedRegions = dropdownOptions.filter(item => item.selected)     //regions checked
+    const allVisibleRegions = [...selectedRegions, dropdownOptions.find(item=>item.region===region)] //all curves on graph
+    
+    let yMin = Number.POSITIVE_INFINITY
+    let yMax = Number.NEGATIVE_INFINITY
 
-    const newLineCurves = []
-    for (const i of selectedRegions) {
-      const curve = lineCurves.find(
-        (item) => item.region === i.region && item.region !== region,
-      )
-      if (curve) {
-        newLineCurves.push(curve)
-      }
+    for(const i of allVisibleRegions){
+      yMin = Math.min(yMin, Math.min(...i.data.map(val=>val.value)))
+      yMax = Math.max(yMax, Math.max(...i.data.map(val=>val.value)))
     }
-    setCurrLineCurves(newLineCurves)
+
+    setYMin(yMin)
+    setyMax(yMax)
+
+    const y = d3
+    .scaleLinear()
+    .domain([yMin, yMax])
+    .range([graphHeight + offset, offset])
+    const x = d3
+      .scaleLinear()
+      .domain([xMin, xMax])
+      .range([leftMargin, graphWidth])
+
+      setCurrGradient({
+        color: colorMap[region],
+        curve: d3
+          .area<DataPoint>()
+          .x((d) => x(d.year))
+          .y1((d) => y(d.value))
+          .y0(graphHeight + offset)
+          .curve(d3.curveBumpX)(
+          dropdownOptions.find((item) => item.region === region).data,
+        ),
+        region: region,
+      })
+
+    setCurrGradientCurve({
+        color: colorMap[region],
+        curve: d3
+          .line<DataPoint>()
+          .x((d) => x(d.year))
+          .y((d) => y(d.value))
+          .curve(d3.curveBumpX)(
+          dropdownOptions.find((item) => item.region === region).data,
+        ),
+        region: region,
+      })
+
+    const lineCurves = []
+    for (const i of selectedRegions) {
+      const curve = {
+        color: colorMap[i.region],
+        curve: d3
+          .line<DataPoint>()
+          .x((d) => x(d.year))
+          .y((d) => y(d.value))
+          .curve(d3.curveBumpX)(i.data),
+        region: i.region,
+      }
+      lineCurves.push(curve)
+    }
+    setCurrLineCurves(lineCurves)  
+
   }, [numSelected])
 
   return (
@@ -299,7 +317,7 @@ export const RegionalComparison = ({ region }: RegionalComparisonProps) => {
           )}
         </View>
       </View>
-      {gradientCurve && currLineCurves && (
+      {currGradientCurve && currLineCurves && (
         <View style={styles.graphContainer}>
           <View style={styles.graphInnerContainer}>
             <GraphKey label={region.toUpperCase()} color={colorMap[region]} />
@@ -313,7 +331,10 @@ export const RegionalComparison = ({ region }: RegionalComparisonProps) => {
                 />
               ))}
             <LineGraph
-              gradientCurve={gradientCurve}
+              yMin={yMin}
+              yMax={yMax}
+              gradient={currGradient}
+              gradientCurve={currGradientCurve}
               lineCurves={currLineCurves}
             />
           </View>

--- a/TECApp/src/components/DataVisualizations/RegionalComparison.tsx
+++ b/TECApp/src/components/DataVisualizations/RegionalComparison.tsx
@@ -223,7 +223,7 @@ export const RegionalComparison = ({ region }: RegionalComparisonProps) => {
         .x((d) => x(d.year))
         .y1((d) => y(d.value))
         .y0(graphHeight + offset)
-        .curve(d3.curveBumpX)(
+        .curve(d3.curveMonotoneX)(
         dropdownOptions.find((item) => item.region === region).data,
       ),
       region: region,
@@ -235,7 +235,7 @@ export const RegionalComparison = ({ region }: RegionalComparisonProps) => {
         .line<DataPoint>()
         .x((d) => x(d.year))
         .y((d) => y(d.value))
-        .curve(d3.curveBumpX)(
+        .curve(d3.curveMonotoneX)(
         dropdownOptions.find((item) => item.region === region).data,
       ),
       region: region,
@@ -249,7 +249,7 @@ export const RegionalComparison = ({ region }: RegionalComparisonProps) => {
           .line<DataPoint>()
           .x((d) => x(d.year))
           .y((d) => y(d.value))
-          .curve(d3.curveBumpX)(i.data),
+          .curve(d3.curveMonotoneX)(i.data),
         region: i.region,
       }
       lineCurves.push(curve)


### PR DESCRIPTION
Made graph y-axis labels dynamic instead of a static 0-20; based on min and max of dataset and ranges between it (results in decimals in axes but I don't really see any way around this). Dynamically adjusts curves and labels when curves of different scales are selected (e.g. North America vs Sub-Saharan Africa)

<img width="365" alt="Screenshot 2024-07-22 at 10 14 39 PM" src="https://github.com/user-attachments/assets/96b0ef93-7e37-4699-82f9-c532bb6c5a01">
<img width="371" alt="Screenshot 2024-07-22 at 10 14 50 PM" src="https://github.com/user-attachments/assets/7f76aa46-f5f7-4446-905b-987df6313f48">
