### PR TITLE
Carbon Budget Graph

### DIFF
--- a/TECApp/src/components/BottomSheet.tsx
+++ b/TECApp/src/components/BottomSheet.tsx
@@ -19,7 +19,7 @@ export const BottomSheet = ({
 
   useEffect(() => {
     if (selectedRegion === 'Global') {
-      bottomSheetRef.current.snapToIndex(0)
+      bottomSheetRef.current.snapToIndex(0) // Snap to 12.5% for global dashboard
     } else {
       bottomSheetRef.current?.snapToIndex(2) // Snap to 25% when a region is selected
     }

--- a/TECApp/src/components/DataVisualizations/BAUComparison.tsx
+++ b/TECApp/src/components/DataVisualizations/BAUComparison.tsx
@@ -6,7 +6,6 @@ import { LineGraph } from './LineGraph'
 const vw = Dimensions.get('window').width
 
 const graphHeight = 190
-const offset = 20
 
 const graphWidth = vw * 0.8
 const leftMargin = 60
@@ -30,10 +29,13 @@ const dummyAltered = [
   { year: 2030, value: Math.random() * 12 + 4 },
 ]
 
+//min of both datasets
 const yMin = Math.min(
   Math.min(...dummyBAU.map((val) => val.value)),
   Math.min(...dummyAltered.map((val) => val.value)),
 )
+
+//max of both datasets
 const yMax = Math.max(
   Math.max(...dummyBAU.map((val) => val.value)),
   Math.max(...dummyAltered.map((val) => val.value)),
@@ -52,28 +54,30 @@ type BAUComparisonProps = {
 }
 
 export const BAUComparison = ({ region }: BAUComparisonProps) => {
-  const y = d3
-    .scaleLinear()
-    .domain([yMin, yMax])
-    .range([graphHeight + offset, offset])
+  //define y-axis scale
+  const y = d3.scaleLinear().domain([yMin, yMax]).range([graphHeight, 0])
+  //define x-axis scale
   const x = d3
     .scaleLinear()
     .domain([xMin, xMax])
     .range([leftMargin, graphWidth])
 
+  //define BAU area curve (just gradient)
   const BAU_gradient = d3
     .area<DataPoint>()
     .x((d) => x(d.year))
     .y1((d) => y(d.value))
-    .y0(graphHeight + offset)
+    .y0(graphHeight)
     .curve(d3.curveMonotoneX)(dummyBAU)
 
+  //define BAU line curve
   const BAU_curve = d3
     .line<DataPoint>()
     .x((d) => x(d.year))
     .y((d) => y(d.value))
     .curve(d3.curveMonotoneX)(dummyBAU)
 
+  //define altered renewables line curve
   const altered_curve = d3
     .line<DataPoint>()
     .x((d) => x(d.year))

--- a/TECApp/src/components/DataVisualizations/CarbonBudget.tsx
+++ b/TECApp/src/components/DataVisualizations/CarbonBudget.tsx
@@ -33,10 +33,9 @@ const dummyData = [
 ]
 
 const dummy1Point5Limit = 10
-const dummy2Point0Limit = 18
+const dummy2Point0Limit = 20
 
 const yMin = Math.min(...dummyData.map((val) => val.value))
-
 const yMax = Math.max(...dummyData.map((val) => val.value))
 
 const xMin = 2024
@@ -65,10 +64,7 @@ export const CarbonBudget = () => {
 
   const dummyData2 = dummyData.filter((val) => val.year >= dummy2Point0Year)
 
-  const y = d3
-    .scaleLinear()
-    .domain([yMin, yMax])
-    .range([graphHeight + offset, offset])
+  const y = d3.scaleLinear().domain([yMin, yMax]).range([graphHeight, 0])
   const x = d3
     .scaleLinear()
     .domain([xMin, xMax])
@@ -78,14 +74,14 @@ export const CarbonBudget = () => {
     .area<DataPoint>()
     .x((d) => x(d.year))
     .y1((d) => y(d.value))
-    .y0(graphHeight + offset)
+    .y0(graphHeight)
     .curve(d3.curveMonotoneX)(dummyData1)
 
   const carbon_gradient2 = d3
     .area<DataPoint>()
     .x((d) => x(d.year))
     .y1((d) => y(d.value))
-    .y0(graphHeight + offset)
+    .y0(graphHeight)
     .curve(d3.curveMonotoneX)(dummyData2)
 
   const carbon_curve1 = d3
@@ -112,6 +108,12 @@ export const CarbonBudget = () => {
   ]
   const horizontalAxis = [2024, 2026, 2028, 2030]
 
+  //helper method for calculating y coordinate based on graph value
+  //calculated as proportion of graph height from the top
+  const calculateY = (val: number) => {
+    return (graphHeight * (yMax - val)) / yRange
+  }
+
   return (
     <View style={{ width: '100%' }}>
       <Text style={styles.header}>Carbon Budget</Text>
@@ -136,21 +138,21 @@ export const CarbonBudget = () => {
               </LinearGradient>
             </Defs>
             {/* Graph frame */}
-            <G>
+            <G y={offset}>
               {verticalAxis.map((e, key) => (
                 <G key={key}>
                   <Line
                     key={key}
                     x1={leftMargin}
                     x2={graphWidth}
-                    y1={(graphHeight * (e - yMin)) / yRange + offset}
-                    y2={(graphHeight * (e - yMin)) / yRange + offset}
+                    y1={calculateY(e)}
+                    y2={calculateY(e)}
                     stroke="#E9E9E9"
                     strokeWidth={2}
                   />
                   <TextSvg
                     strokeWidth={0.1}
-                    y={(graphHeight * (yMax - e)) / yRange + offset + 3.5}
+                    y={calculateY(e) + 3.5}
                     x={e >= 10 ? leftMargin - 25 : leftMargin - 20}
                     fontSize={10}
                     fill="#9E9FA7"
@@ -168,7 +170,7 @@ export const CarbonBudget = () => {
                 fontWeight={400}
                 fontFamily="Roboto"
                 fontSize={14}
-                x={-(graphHeight + offset - 50)}
+                x={-(graphHeight - 50)}
                 y={15}
               >
                 Emissions (GT)
@@ -177,7 +179,7 @@ export const CarbonBudget = () => {
                 <TextSvg
                   key={key}
                   x={graphWidth * (-(2024 - e) / 8.3) + leftMargin}
-                  y={graphHeight + offset + 25}
+                  y={graphHeight + 25}
                   strokeWidth={0.1}
                   fontWeight={700}
                   fontSize={10}
@@ -195,13 +197,13 @@ export const CarbonBudget = () => {
                 fontFamily="Roboto"
                 fontSize={14}
                 x={graphWidth / 2}
-                y={graphHeight + offset + 50}
+                y={graphHeight + 50}
               >
                 Years
               </TextSvg>
             </G>
             {/* Graph Curves */}
-            <G>
+            <G y={offset}>
               <Path d={carbon_gradient1} strokeWidth={0} fill={'url(#grad1)'} />
               <Path d={carbon_gradient2} strokeWidth={0} fill={'url(#grad2)'} />
               <Path
@@ -218,13 +220,7 @@ export const CarbonBudget = () => {
               />
               <Rect
                 x={leftMargin}
-                y={
-                  (graphHeight *
-                    (yMax - dummyData1[dummyData1.length - 1].value)) /
-                    yRange +
-                  offset -
-                  25
-                }
+                y={calculateY(dummyData1[dummyData1.length - 1].value) - 25}
                 width={62}
                 height={20}
                 rx={4}
@@ -241,13 +237,7 @@ export const CarbonBudget = () => {
                 letterSpacing={0.787}
                 fontSize={8}
                 x={leftMargin + 3}
-                y={
-                  (graphHeight *
-                    (yMax - dummyData1[dummyData1.length - 1].value)) /
-                    yRange +
-                  offset -
-                  12
-                }
+                y={calculateY(dummyData1[dummyData1.length - 1].value) - 12}
               >
                 2.0°C LIMIT
               </TextSvg>
@@ -255,32 +245,18 @@ export const CarbonBudget = () => {
                 strokeDasharray="6"
                 x1={leftMargin}
                 x2={graphWidth}
-                y1={
-                  (graphHeight *
-                    (yMax - dummyData1[dummyData1.length - 1].value)) /
-                    yRange +
-                  offset
-                }
-                y2={
-                  (graphHeight *
-                    (yMax - dummyData1[dummyData1.length - 1].value)) /
-                    yRange +
-                  offset
-                }
+                y1={calculateY(dummyData1[dummyData1.length - 1].value)}
+                y2={calculateY(dummyData1[dummyData1.length - 1].value)}
                 stroke="#58C4D4"
                 strokeWidth={1}
               />
               <Rect
-              opacity={0.5}
+                opacity={0.5}
                 x={leftMargin}
                 y={
-                  (graphHeight *
-                    (yMax -
-                      dummyData.find((val) => val.year == dummy1Point5Year)
-                        .value)) /
-                    yRange +
-                  offset -
-                  25
+                  calculateY(
+                    dummyData.find((val) => val.year == dummy1Point5Year).value,
+                  ) - 25
                 }
                 width={62}
                 height={20}
@@ -291,7 +267,7 @@ export const CarbonBudget = () => {
                 strokeWidth={1}
               />
               <TextSvg
-              opacity={0.5}
+                opacity={0.5}
                 stroke="#58C4D4"
                 fill="#58C4D4"
                 strokeWidth={0.05}
@@ -300,38 +276,24 @@ export const CarbonBudget = () => {
                 fontSize={8}
                 x={leftMargin + 3}
                 y={
-                  (graphHeight *
-                    (yMax -
-                      dummyData.find((val) => val.year == dummy1Point5Year)
-                        .value)) /
-                    yRange +
-                  offset -
-                  12
+                  calculateY(
+                    dummyData.find((val) => val.year == dummy1Point5Year).value,
+                  ) - 12
                 }
               >
                 1.5°C LIMIT
               </TextSvg>
               <Line
-              opacity={0.5}
+                opacity={0.5}
                 strokeDasharray="6"
                 x1={leftMargin}
                 x2={graphWidth}
-                y1={
-                  (graphHeight *
-                    (yMax -
-                      dummyData.find((val) => val.year == dummy1Point5Year)
-                        .value)) /
-                    yRange +
-                  offset
-                }
-                y2={
-                  (graphHeight *
-                    (yMax -
-                      dummyData.find((val) => val.year == dummy1Point5Year)
-                        .value)) /
-                    yRange +
-                  offset
-                }
+                y1={calculateY(
+                  dummyData.find((val) => val.year == dummy1Point5Year).value,
+                )}
+                y2={calculateY(
+                  dummyData.find((val) => val.year == dummy1Point5Year).value,
+                )}
                 stroke="#58C4D4"
                 strokeWidth={1}
               />

--- a/TECApp/src/components/DataVisualizations/CarbonBudget.tsx
+++ b/TECApp/src/components/DataVisualizations/CarbonBudget.tsx
@@ -50,6 +50,7 @@ export const CarbonBudget = () => {
   let sum = 0
   let dummy1Point5Year: number
   let dummy2Point0Year: number
+  //calculating x-axis position of each temperature limit
   for (const i of dummyData) {
     sum += i.value
     if (!dummy1Point5Year && sum > dummy1Point5Limit) {
@@ -60,8 +61,8 @@ export const CarbonBudget = () => {
     }
   }
 
+  //separate data based on 2 degree limit
   const dummyData1 = dummyData.filter((val) => val.year <= dummy2Point0Year)
-
   const dummyData2 = dummyData.filter((val) => val.year >= dummy2Point0Year)
 
   const y = d3.scaleLinear().domain([yMin, yMax]).range([graphHeight, 0])

--- a/TECApp/src/components/DataVisualizations/CarbonBudget.tsx
+++ b/TECApp/src/components/DataVisualizations/CarbonBudget.tsx
@@ -1,0 +1,369 @@
+import * as d3 from 'd3'
+import React from 'react'
+import { View, Text, StyleSheet, Dimensions } from 'react-native'
+import Svg, {
+  Defs,
+  G,
+  Line,
+  LinearGradient,
+  Path,
+  Rect,
+  Stop,
+  Text as TextSvg,
+} from 'react-native-svg'
+import { GraphKey } from './GraphKey'
+
+const vw = Dimensions.get('window').width
+
+const svgHeight = 300
+const graphHeight = 190
+const offset = 20
+
+const graphWidth = vw * 0.8
+const leftMargin = 60
+
+const dummyData = [
+  { year: 2024, value: 4 },
+  { year: 2025, value: 4.4 },
+  { year: 2026, value: 4.9 },
+  { year: 2027, value: 5.4 },
+  { year: 2028, value: 5.8 },
+  { year: 2029, value: 6.2 },
+  { year: 2030, value: 6.3 },
+]
+
+const dummy1Point5Limit = 10
+const dummy2Point0Limit = 18
+
+const yMin = Math.min(...dummyData.map((val) => val.value))
+
+const yMax = Math.max(...dummyData.map((val) => val.value))
+
+const xMin = 2024
+const xMax = 2030
+
+type DataPoint = {
+  year: number
+  value: number
+}
+
+export const CarbonBudget = () => {
+  let sum = 0
+  let dummy1Point5Year: number
+  let dummy2Point0Year: number
+  for (const i of dummyData) {
+    sum += i.value
+    if (!dummy1Point5Year && sum > dummy1Point5Limit) {
+      dummy1Point5Year = i.year
+    }
+    if (!dummy2Point0Year && sum > dummy2Point0Limit) {
+      dummy2Point0Year = i.year
+    }
+  }
+
+  const dummyData1 = dummyData.filter((val) => val.year <= dummy2Point0Year)
+
+  const dummyData2 = dummyData.filter((val) => val.year >= dummy2Point0Year)
+
+  const y = d3
+    .scaleLinear()
+    .domain([yMin, yMax])
+    .range([graphHeight + offset, offset])
+  const x = d3
+    .scaleLinear()
+    .domain([xMin, xMax])
+    .range([leftMargin, graphWidth])
+
+  const carbon_gradient1 = d3
+    .area<DataPoint>()
+    .x((d) => x(d.year))
+    .y1((d) => y(d.value))
+    .y0(graphHeight + offset)
+    .curve(d3.curveMonotoneX)(dummyData1)
+
+  const carbon_gradient2 = d3
+    .area<DataPoint>()
+    .x((d) => x(d.year))
+    .y1((d) => y(d.value))
+    .y0(graphHeight + offset)
+    .curve(d3.curveMonotoneX)(dummyData2)
+
+  const carbon_curve1 = d3
+    .line<DataPoint>()
+    .x((d) => x(d.year))
+    .y((d) => y(d.value))
+    .curve(d3.curveMonotoneX)(dummyData1)
+
+  const carbon_curve2 = d3
+    .line<DataPoint>()
+    .x((d) => x(d.year))
+    .y((d) => y(d.value))
+    .curve(d3.curveMonotoneX)(dummyData2)
+
+  const yRange = yMax - yMin
+
+  const verticalAxis = [
+    yMin,
+    yMin + yRange * 0.2,
+    yMin + yRange * 0.4,
+    yMin + yRange * 0.6,
+    yMin + yRange * 0.8,
+    yMax,
+  ]
+  const horizontalAxis = [2024, 2026, 2028, 2030]
+
+  return (
+    <View style={{ width: '100%' }}>
+      <Text style={styles.header}>Carbon Budget</Text>
+      <Text style={styles.body}>
+        This graph shows the resulting emissions in gigatons (GT) of your
+        manipulated global renewables over time. The area under the curve shows
+        the amount of emissions you’re allowed to emit before exceeding the
+        global temperature threshold.
+      </Text>
+      <View style={styles.graphContainer}>
+        <View style={styles.graphInnerContainer}>
+          <GraphKey label="CUMULATIVE CARBON EMISSIONS" color="#266297" />
+          <Svg width={graphWidth} height={svgHeight}>
+            <Defs>
+              <LinearGradient id="grad1" x1="0" y1="0" x2="0" y2="1">
+                <Stop stopColor="#58C4D4" />
+                <Stop offset="1" stopColor="#58C4D4" stopOpacity={0} />
+              </LinearGradient>
+              <LinearGradient id="grad2" x1="0" y1="0" x2="0" y2="1">
+                <Stop stopColor="#9E9FA7" />
+                <Stop offset="1" stopColor="#9E9FA7" stopOpacity={0} />
+              </LinearGradient>
+            </Defs>
+            {/* Graph frame */}
+            <G>
+              {verticalAxis.map((e, key) => (
+                <G key={key}>
+                  <Line
+                    key={key}
+                    x1={leftMargin}
+                    x2={graphWidth}
+                    y1={(graphHeight * (e - yMin)) / yRange + offset}
+                    y2={(graphHeight * (e - yMin)) / yRange + offset}
+                    stroke="#E9E9E9"
+                    strokeWidth={2}
+                  />
+                  <TextSvg
+                    strokeWidth={0.1}
+                    y={(graphHeight * (yMax - e)) / yRange + offset + 3.5}
+                    x={e >= 10 ? leftMargin - 25 : leftMargin - 20}
+                    fontSize={10}
+                    fill="#9E9FA7"
+                    stroke="#9E9FA7"
+                  >
+                    {e.toFixed(1)}
+                  </TextSvg>
+                </G>
+              ))}
+              <TextSvg
+                transform="rotate(270)"
+                stroke="#000"
+                fill="#000"
+                strokeWidth={0.05}
+                fontWeight={400}
+                fontFamily="Roboto"
+                fontSize={14}
+                x={-(graphHeight + offset - 50)}
+                y={15}
+              >
+                Emissions (GT)
+              </TextSvg>
+              {horizontalAxis.map((e, key) => (
+                <TextSvg
+                  key={key}
+                  x={graphWidth * (-(2024 - e) / 8.3) + leftMargin}
+                  y={graphHeight + offset + 25}
+                  strokeWidth={0.1}
+                  fontWeight={700}
+                  fontSize={10}
+                  fill="#9E9FA7"
+                  stroke="#9E9FA7"
+                >
+                  {e}
+                </TextSvg>
+              ))}
+              <TextSvg
+                stroke="#000"
+                fill="#000"
+                strokeWidth={0.05}
+                fontWeight={400}
+                fontFamily="Roboto"
+                fontSize={14}
+                x={graphWidth / 2}
+                y={graphHeight + offset + 50}
+              >
+                Years
+              </TextSvg>
+            </G>
+            {/* Graph Curves */}
+            <G>
+              <Path d={carbon_gradient1} strokeWidth={0} fill={'url(#grad1)'} />
+              <Path d={carbon_gradient2} strokeWidth={0} fill={'url(#grad2)'} />
+              <Path
+                d={carbon_curve1}
+                strokeWidth={2}
+                stroke="#266297"
+                fill="none"
+              />
+              <Path
+                d={carbon_curve2}
+                strokeWidth={2}
+                stroke="#266297"
+                fill="none"
+              />
+              <Rect
+                x={leftMargin}
+                y={
+                  (graphHeight *
+                    (yMax - dummyData1[dummyData1.length - 1].value)) /
+                    yRange +
+                  offset -
+                  25
+                }
+                width={62}
+                height={20}
+                rx={4}
+                ry={4}
+                fill="none"
+                stroke="#58C4D4"
+                strokeWidth={1}
+              />
+              <TextSvg
+                stroke="#58C4D4"
+                fill="#58C4D4"
+                strokeWidth={0.05}
+                fontWeight={400}
+                letterSpacing={0.787}
+                fontSize={8}
+                x={leftMargin + 3}
+                y={
+                  (graphHeight *
+                    (yMax - dummyData1[dummyData1.length - 1].value)) /
+                    yRange +
+                  offset -
+                  12
+                }
+              >
+                2.0°C LIMIT
+              </TextSvg>
+              <Line
+                strokeDasharray="6"
+                x1={leftMargin}
+                x2={graphWidth}
+                y1={
+                  (graphHeight *
+                    (yMax - dummyData1[dummyData1.length - 1].value)) /
+                    yRange +
+                  offset
+                }
+                y2={
+                  (graphHeight *
+                    (yMax - dummyData1[dummyData1.length - 1].value)) /
+                    yRange +
+                  offset
+                }
+                stroke="#58C4D4"
+                strokeWidth={1}
+              />
+              <Rect
+              opacity={0.5}
+                x={leftMargin}
+                y={
+                  (graphHeight *
+                    (yMax -
+                      dummyData.find((val) => val.year == dummy1Point5Year)
+                        .value)) /
+                    yRange +
+                  offset -
+                  25
+                }
+                width={62}
+                height={20}
+                rx={4}
+                ry={4}
+                fill="none"
+                stroke="#58C4D4"
+                strokeWidth={1}
+              />
+              <TextSvg
+              opacity={0.5}
+                stroke="#58C4D4"
+                fill="#58C4D4"
+                strokeWidth={0.05}
+                fontWeight={400}
+                letterSpacing={0.787}
+                fontSize={8}
+                x={leftMargin + 3}
+                y={
+                  (graphHeight *
+                    (yMax -
+                      dummyData.find((val) => val.year == dummy1Point5Year)
+                        .value)) /
+                    yRange +
+                  offset -
+                  12
+                }
+              >
+                1.5°C LIMIT
+              </TextSvg>
+              <Line
+              opacity={0.5}
+                strokeDasharray="6"
+                x1={leftMargin}
+                x2={graphWidth}
+                y1={
+                  (graphHeight *
+                    (yMax -
+                      dummyData.find((val) => val.year == dummy1Point5Year)
+                        .value)) /
+                    yRange +
+                  offset
+                }
+                y2={
+                  (graphHeight *
+                    (yMax -
+                      dummyData.find((val) => val.year == dummy1Point5Year)
+                        .value)) /
+                    yRange +
+                  offset
+                }
+                stroke="#58C4D4"
+                strokeWidth={1}
+              />
+            </G>
+          </Svg>
+        </View>
+      </View>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  header: {
+    fontFamily: 'Brix Sans',
+    fontSize: 24,
+    marginBottom: 8,
+  },
+  body: {
+    fontFamily: 'Roboto',
+    fontSize: 14,
+  },
+  graphContainer: {
+    width: '90%',
+    display: 'flex',
+    alignItems: 'center',
+    marginTop: 20,
+  },
+  graphInnerContainer: {
+    width: vw * 0.8,
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'flex-end',
+    gap: 4,
+  },
+})

--- a/TECApp/src/components/DataVisualizations/DataVisualizations.tsx
+++ b/TECApp/src/components/DataVisualizations/DataVisualizations.tsx
@@ -3,6 +3,7 @@ import { Text, StyleSheet, View, ScrollView } from 'react-native'
 import { TouchableOpacity } from 'react-native-gesture-handler'
 import { BAUComparison } from './BAUComparison'
 import { RegionalComparison } from './RegionalComparison'
+import { CarbonBudget } from './CarbonBudget'
 
 type DataVisualizationsProps = {
   region: string
@@ -81,7 +82,7 @@ const DataVisualizations = ({ region }: DataVisualizationsProps) => {
       ) : activeButton === 'Regional Comparison' ? (
         <RegionalComparison region={region} />
       ) : (
-        <></>
+        <CarbonBudget />
       )}
     </ScrollView>
   )

--- a/TECApp/src/components/DataVisualizations/LineGraph.tsx
+++ b/TECApp/src/components/DataVisualizations/LineGraph.tsx
@@ -11,9 +11,9 @@ import Svg, {
 
 const vw = Dimensions.get('window').width
 
-const svgHeight = 300
-const graphHeight = 190
-const offset = 20
+const svgHeight = 300 //height of whole svg
+const graphHeight = 190 //height of graph graph
+const offset = 20 //graph starts this amount from the top of the svg container (allows for axes label to peek out above strict graph limits)
 
 const graphWidth = vw * 0.8
 const leftMargin = 60
@@ -24,12 +24,16 @@ export type CurveObject = {
   region?: string
 }
 
+/*
+ * Note: we separate gradient and gradientCurve because having a single area curve
+ * forces borders on all sides when we only want the stroked curve on the top of the gradient
+ */
 type LineGraphProps = {
-  gradient: CurveObject
-  gradientCurve: CurveObject
-  lineCurves: CurveObject[]
-  yMin: number
-  yMax: number
+  gradient: CurveObject //area curve for gradient
+  gradientCurve: CurveObject //line curve for gradient border
+  lineCurves: CurveObject[] //generic line curves
+  yMin: number //minimum y-axis value of data
+  yMax: number //maximum y-axis value of data
 }
 
 export const LineGraph = ({
@@ -41,6 +45,7 @@ export const LineGraph = ({
 }: LineGraphProps) => {
   const yRange = yMax - yMin
 
+  //y-axis label calculations
   const verticalAxis = [
     yMin,
     yMin + yRange * 0.2,
@@ -51,8 +56,15 @@ export const LineGraph = ({
   ]
   const horizontalAxis = [2024, 2026, 2028, 2030]
 
+  //helper method for calculating y coordinate based on graph value
+  //calculated as proportion of graph height from the top
+  const calculateY = (val: number) => {
+    return (graphHeight * (yMax - val)) / yRange
+  }
+
   return (
     <Svg width={graphWidth} height={svgHeight}>
+      {/* Gradient definitions*/}
       <Defs>
         <LinearGradient id="grad" x1="0" y1="0" x2="0" y2="1">
           <Stop offset="0" stopColor={gradientCurve.color} stopOpacity={0.9} />
@@ -61,24 +73,22 @@ export const LineGraph = ({
       </Defs>
 
       {/* Graph frame */}
-      <G>
+      <G y={offset}>
         {verticalAxis.map((e, key) => (
           <G key={key}>
             <Line
               key={key}
               x1={leftMargin}
               x2={graphWidth}
-              y1={(graphHeight * (e - yMin)) / yRange + offset}
-              y2={(graphHeight * (e - yMin)) / yRange + offset}
+              y1={calculateY(e)}
+              y2={calculateY(e)}
               stroke="#E9E9E9"
               strokeWidth={2}
             />
             <TextSvg
               strokeWidth={0.1}
-              y={
-                (graphHeight * (yMax + yMin - e - yMin)) / yRange + offset + 3.5
-              }
-              x={e >= 10 ? leftMargin - 25 : leftMargin - 20}
+              y={calculateY(e) + 3.5}
+              x={e >= 10 ? leftMargin - 25 : leftMargin - 20} //double digits take up more space
               fontSize={10}
               fill="#9E9FA7"
               stroke="#9E9FA7"
@@ -95,7 +105,7 @@ export const LineGraph = ({
           fontWeight={400}
           fontFamily="Roboto"
           fontSize={14}
-          x={-(graphHeight + offset - 30)}
+          x={-(graphHeight - 30)}
           y={15}
         >
           Renewable Capacity (TW)
@@ -104,7 +114,7 @@ export const LineGraph = ({
           <TextSvg
             key={key}
             x={graphWidth * (-(2024 - e) / 8.3) + leftMargin}
-            y={graphHeight + offset + 25}
+            y={graphHeight + 25}
             strokeWidth={0.1}
             fontWeight={700}
             fontSize={10}
@@ -122,13 +132,13 @@ export const LineGraph = ({
           fontFamily="Roboto"
           fontSize={14}
           x={graphWidth / 2}
-          y={graphHeight + offset + 50}
+          y={graphHeight + 50}
         >
           Years
         </TextSvg>
       </G>
       {/* Graph Curves */}
-      <G>
+      <G y={offset}>
         <Path
           d={gradient.curve}
           strokeWidth={0}

--- a/TECApp/src/components/DataVisualizations/RegionalComparison.tsx
+++ b/TECApp/src/components/DataVisualizations/RegionalComparison.tsx
@@ -30,7 +30,6 @@ type RegionalComparisonProps = {
 const vw = Dimensions.get('window').width
 
 const graphHeight = 190
-const offset = 20
 
 const graphWidth = vw * 0.8
 const leftMargin = 60
@@ -162,14 +161,15 @@ export const RegionalComparison = ({ region }: RegionalComparisonProps) => {
     { region: 'OECD Pacific', selected: false, data: dummyOPA },
     { region: 'Greater China', selected: false, data: dummyCHN },
     { region: 'Indian Subcontinent', selected: false, data: dummyIND },
-  ])
-  const [numSelected, setNumSelected] = useState<number>(0)
-  const [yMin, setYMin] = useState<number>()
-  const [yMax, setyMax] = useState<number>()
+  ]) //keeps track of state of every checkbox
+  const [numSelected, setNumSelected] = useState<number>(0) //easier way to keep track than parsing above state every time
 
-  const [currGradient, setCurrGradient] = useState<CurveObject>()
-  const [currGradientCurve, setCurrGradientCurve] = useState<CurveObject>()
-  const [currLineCurves, setCurrLineCurves] = useState<CurveObject[]>()
+  const [yMin, setYMin] = useState<number>() //dynamic yMin based on what's selected
+  const [yMax, setyMax] = useState<number>() //dynamic yMax based on what's selected
+
+  const [currGradient, setCurrGradient] = useState<CurveObject>() //current region gradient
+  const [currGradientCurve, setCurrGradientCurve] = useState<CurveObject>() //current region curve
+  const [currLineCurves, setCurrLineCurves] = useState<CurveObject[]>() //curves of all checked regions
 
   const onCheck = (key: number) => {
     if (numSelected < 4 || dropdownOptions[key].selected) {
@@ -189,12 +189,13 @@ export const RegionalComparison = ({ region }: RegionalComparisonProps) => {
     }
   }
 
+  //all calculations rerun when new region selected/unselected
   useEffect(() => {
     const selectedRegions = dropdownOptions.filter((item) => item.selected) //regions checked
     const allVisibleRegions = [
       ...selectedRegions,
       dropdownOptions.find((item) => item.region === region),
-    ] //all curves on graph
+    ] //regions checked + current region
 
     let yMin = Number.POSITIVE_INFINITY
     let yMax = Number.NEGATIVE_INFINITY
@@ -207,10 +208,7 @@ export const RegionalComparison = ({ region }: RegionalComparisonProps) => {
     setYMin(yMin)
     setyMax(yMax)
 
-    const y = d3
-      .scaleLinear()
-      .domain([yMin, yMax])
-      .range([graphHeight + offset, offset])
+    const y = d3.scaleLinear().domain([yMin, yMax]).range([graphHeight, 0])
     const x = d3
       .scaleLinear()
       .domain([xMin, xMax])
@@ -222,7 +220,7 @@ export const RegionalComparison = ({ region }: RegionalComparisonProps) => {
         .area<DataPoint>()
         .x((d) => x(d.year))
         .y1((d) => y(d.value))
-        .y0(graphHeight + offset)
+        .y0(graphHeight)
         .curve(d3.curveMonotoneX)(
         dropdownOptions.find((item) => item.region === region).data,
       ),

--- a/TECApp/src/components/GlobalDashboard.tsx
+++ b/TECApp/src/components/GlobalDashboard.tsx
@@ -3,13 +3,17 @@ import { View, Text, StyleSheet, TouchableOpacity } from 'react-native'
 import DistributeRenewables from './DistributeRenewables'
 import DataVisualizations from './DataVisualizations/DataVisualizations'
 import { Tracker } from './Tracker'
+import { ScrollView } from 'react-native-gesture-handler'
 
 export const GlobalDashboard = () => {
   const [activeTab, setActiveTab] = useState<'renewables' | 'visualizations'>(
     'renewables',
   )
   return (
-    <View style={styles.regionInfoContainer}>
+    <ScrollView
+      style={styles.regionInfoContainer}
+      contentContainerStyle={{ alignItems: 'flex-start' }}
+    >
       <Text style={styles.regionName}>Global Climate Dashboard</Text>
       <Text style={styles.body}>
         Set default global renewable values and keep track of your progress
@@ -70,7 +74,7 @@ export const GlobalDashboard = () => {
       ) : (
         <DataVisualizations region="Global" />
       )}
-    </View>
+    </ScrollView>
   )
 }
 
@@ -78,7 +82,6 @@ const styles = StyleSheet.create({
   regionInfoContainer: {
     flex: 1,
     width: '100%',
-    alignItems: 'flex-start',
   },
   regionName: {
     color: '#000',

--- a/TECApp/src/components/WelcomePopup.tsx
+++ b/TECApp/src/components/WelcomePopup.tsx
@@ -5,7 +5,7 @@ import { LeftArrow } from '../SVGs/LeftArrow'
 import { PaginationCircle } from '../SVGs/PaginationCircle'
 
 export const WelcomePopup = () => {
-  const [popupState, setPopupState] = useState(0)
+  const [popupState, setPopupState] = useState(0) //states 0-4 represent 5 slides
 
   return (
     <>

--- a/TECApp/src/components/WorldMap.tsx
+++ b/TECApp/src/components/WorldMap.tsx
@@ -10,11 +10,9 @@ export interface WorldMapProps {
 }
 
 export const WorldMap = ({ onSelectCountry }: WorldMapProps) => {
-  const web = Platform.OS == 'web'
-
   const width = Dimensions.get('window').width
   const height = Dimensions.get('window').height
-  const widthScale = web ? 1 : 3
+  const widthScale = 3
 
   const projection = d3
     .geoNaturalEarth1()
@@ -29,14 +27,12 @@ export const WorldMap = ({ onSelectCountry }: WorldMapProps) => {
       initialZoom={1.5}
       maxZoom={3}
       bindToBorders={true}
-      // panBoundaryPadding={500}
       zoomStep={0}
       contentHeight={-500}
       contentWidth={1250}
-      // contentWidth={200}
-      style={web ? webStyles.container : mobileStyles.container}
+      style={styles.container}
     >
-      <Svg style={web ? webStyles.svg : mobileStyles.svg}>
+      <Svg style={styles.svg}>
         <G>
           <Rect
             x={0}
@@ -48,17 +44,12 @@ export const WorldMap = ({ onSelectCountry }: WorldMapProps) => {
           />
           {data.features.map((feature, index) => (
             <Path
-              //@ts-expect-error: weird property error with map
+              // @ts-expect-error: weird property error with map
               d={pathGenerator(feature)}
               key={index}
               stroke="#FFF"
               strokeWidth={2.5}
               fill={feature.properties.color}
-              //@ts-expect-error: to allow clicking to work on web
-              onClick={() => {
-                //onSelectCountry here rather than alert
-                onSelectCountry(feature.properties.region)
-              }}
               onPress={() => {
                 onSelectCountry(feature.properties.region)
               }}
@@ -70,23 +61,7 @@ export const WorldMap = ({ onSelectCountry }: WorldMapProps) => {
   )
 }
 
-const webStyles = StyleSheet.create({
-  container: {
-    width: '100%',
-    height: '100%',
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    // backgroundColor: "white"
-  },
-  svg: {
-    height: '100%',
-    width: '100%',
-    // backgroundColor: "red",
-  },
-})
-
-const mobileStyles = StyleSheet.create({
+const styles = StyleSheet.create({
   container: {
     width: '300%',
     height: '100%',


### PR DESCRIPTION
Resolves #36 

Created carbon budget graph that dynamically changes blue/gray gradient and 1.5/2.0 degree ticks based on when (arbitrary) values are exceeded by the sum of (arbitrary) carbon values from 2024 to a certain year. 

(We definitely need to ask Mike about this interpretation because I still don't know if it's fully correct and I'm also kind of questioning whether or not this is the best way to represent it, just seems very confusing.)

<img width="390" alt="Screenshot 2024-07-25 at 10 15 11 PM" src="https://github.com/user-attachments/assets/80d2454a-a75f-4503-a9a9-4a167cfeea62">
