### PR TITLE
Carbon Budget Graph Changes + IOS Build

### DIFF
--- a/TECApp/app.json
+++ b/TECApp/app.json
@@ -1,6 +1,6 @@
 {
   "expo": {
-    "name": "AwesomeProject",
+    "name": "Triton Energy Climate",
     "slug": "AwesomeProject",
     "scheme": "tec-app",
     "version": "1.0.0",
@@ -16,7 +16,7 @@
       "**/*"
     ],
     "ios": {
-      "bundleIdentifier": "com.AwesomeProject",
+      "bundleIdentifier": "com.CER.TECApp",
       "supportsTablet": true
     },
     "android": {
@@ -33,7 +33,12 @@
         "projectId": "34278a3e-ba24-4041-81dc-9c190a29c4b4"
       }
     },
-    "plugins": [
-    ]
+    "plugins": [],
+    "runtimeVersion": {
+      "policy": "appVersion"
+    },
+    "updates": {
+      "url": "https://u.expo.dev/34278a3e-ba24-4041-81dc-9c190a29c4b4"
+    }
   }
 }

--- a/TECApp/app/api/requests.ts
+++ b/TECApp/app/api/requests.ts
@@ -126,26 +126,29 @@ type YearRange = {
   '2024-2030'?: number
 }
 
-type RawData = {
-  solar?: YearRange
-  wind?: YearRange
-  hydropower?: YearRange
-  geothermal?: YearRange
-  biomass?: YearRange
-  nuclear?: YearRange
-  coal?: YearRange
-  gas?: YearRange
-  oil?: YearRange
-  zero_carbon?: YearRange
+type ElectricityGenerationData = {
+  solar: YearRange
+  wind: YearRange
+  hydropower: YearRange
+  geothermal: YearRange
+  biomass: YearRange
+  nuclear: YearRange
 }
 
-export type RenewableEnergyCalculationData = {
-  installed_capacity: RawData
-  forecast_cagr: RawData
-  forecast_growth_rate: RawData
-  capacity_factor: RawData
-  electricity_generation: RawData
-  co2_emissions: RawData
+type CarbonBudgetData = {
+  coal: number
+  gas: number
+  oil: number
+  zero_carbon: number
+}
+
+export type CalculationData = {
+  installed_capacity: ElectricityGenerationData
+  forecast_cagr: ElectricityGenerationData
+  forecast_growth_rate: ElectricityGenerationData
+  capacity_factor: ElectricityGenerationData
+  electricity_generation: CarbonBudgetData,
+  co2_emissions: CarbonBudgetData,
   region: string
 }
 
@@ -155,12 +158,5 @@ export type RenewableEnergyCalculationData = {
  */
 export async function getRegionCalculationData(region: string) {
   const response = await fetch(BASE_URL + `/calc/${region}`, { method: 'GET' })
-  return (await response.json()) as RenewableEnergyCalculationData
-}
-
-export async function getInitialFossilData() {
-  const response = await fetch(BASE_URL + '/fossil-emissions', {
-    method: 'GET',
-  })
-  return (await response.json()) as DataPoint[]
+  return (await response.json()) as CalculationData
 }

--- a/TECApp/app/api/requests.ts
+++ b/TECApp/app/api/requests.ts
@@ -1,6 +1,6 @@
 import { DataPoint } from '../components/DataVisualizations/BAUComparison'
 
-const BASE_URL = process.env.EXPO_PUBLIC_BACKEND_URL
+const BASE_URL = process.env.EXPO_PUBLIC_BACKEND_URL || "http://localhost:3001"
 
 export type DefaultValues = {
   region: string

--- a/TECApp/app/components/BottomSheet.tsx
+++ b/TECApp/app/components/BottomSheet.tsx
@@ -110,8 +110,8 @@ export const BottomSheet = ({
 
   const initializeFossilData = () => {
     let initialFossilData = []
-    initialFossilData.push({year: 2025, value: 33.3})
-    initialFossilData.push({year: 2030, value: 31.6})
+    initialFossilData.push({year: 2025, value: 33.3+3.82+5.0-0.1})
+    initialFossilData.push({year: 2030, value: 31.6+3.82+5.0-0.2})
     for(let i = 2035; i<=2060; i+=5){
       initialFossilData.push({year: i, value: 0})
     }

--- a/TECApp/app/components/BottomSheet.tsx
+++ b/TECApp/app/components/BottomSheet.tsx
@@ -6,15 +6,15 @@ import {
   GraphData,
   RegionalMinMaxValues,
   RegionalValues,
-  RenewableEnergyCalculationData,
+  CalculationData,
   getDefaultValues,
-  getInitialFossilData,
   getInitialGraphData,
   getMinMaxValues,
   getRegionCalculationData,
 } from '../api/requests'
 import { getAbbrv, getEnergyAbbrv } from '../util/ValueDictionaries'
 import {
+  calculateCarbonCurve,
   calculateCarbonReductions,
   calculateEnergyCurve,
   calculateNewGlobalOnReset,
@@ -29,16 +29,16 @@ export interface BottomSheetProps {
 }
 
 export type FossilReductionData = {
-  chn: DataPoint[]
-  nam: DataPoint[]
-  lam: DataPoint[]
-  ind: DataPoint[]
-  sea: DataPoint[]
-  mea: DataPoint[]
-  opa: DataPoint[]
-  eur: DataPoint[]
-  ssa: DataPoint[]
-  nee: DataPoint[]
+  chn: number
+  nam: number
+  lam: number
+  ind: number
+  sea: number
+  mea: number
+  opa: number
+  eur: number
+  ssa: number
+  nee: number
 }
 
 const regions = [
@@ -78,6 +78,9 @@ export const BottomSheet = ({
   const [fossilReductionData, setFossilReductionData] =
     useState<FossilReductionData>() //carbon reduction data (to be applied to fossil data above)
 
+  const [calculationData, setCalculationData] =
+    useState<CalculationData>() //storage of all necessary calculation data for the current region
+
   const calculateTotalGlobalEnergy = (sliderValues: RegionalValues) => {
     let totalEnergy = 0
 
@@ -105,8 +108,24 @@ export const BottomSheet = ({
     }
   }
 
-  const [calculationData, setCalculationData] =
-    useState<RenewableEnergyCalculationData>() //storage of all necessary calculation data for the current region
+  const initializeFossilData = () => {
+    let initialFossilData = []
+    initialFossilData.push({year: 2025, value: 33.3})
+    initialFossilData.push({year: 2030, value: 31.6})
+    for(let i = 2035; i<=2060; i+=5){
+      initialFossilData.push({year: i, value: 0})
+    }
+    initialFossilData = calculateCarbonCurve(0, initialFossilData)
+    setDynamicFossilData(initialFossilData)
+    storeData("bau-fossil-data", JSON.stringify(initialFossilData))
+    storeData("dynamic-fossil-data", JSON.stringify(initialFossilData))
+
+    const initialFossilReductionData = {} as FossilReductionData
+    for (const region of regions) {
+      initialFossilReductionData[region] = 0
+    }
+    setFossilReductionData(initialFossilReductionData)
+  }
 
   //pull all initial data
   useEffect(() => {
@@ -138,25 +157,8 @@ export const BottomSheet = ({
 
       })
       .catch(console.error)
-    getInitialFossilData().then((val) => {
-      setDynamicFossilData(val)
 
-      storeData("bau-fossil-data", JSON.stringify(val))
-      storeData("dynamic-fossil-data", JSON.stringify(val))
-    })
-
-    const initialFossilReductionData = {} as FossilReductionData
-    for (const region of regions) {
-      initialFossilReductionData[region] = [
-        { year: 2025, value: 0 },
-        { year: 2026, value: 0 },
-        { year: 2027, value: 0 },
-        { year: 2028, value: 0 },
-        { year: 2029, value: 0 },
-        { year: 2030, value: 0 },
-      ]
-    }
-    setFossilReductionData(initialFossilReductionData)
+    initializeFossilData()
   }, [])
 
   //update regional calculation data on region select
@@ -223,41 +225,14 @@ export const BottomSheet = ({
                 })
                 storeData("dynamic-graph-data", JSON.stringify(globalGraphData))
 
-                const newRegionFossilReductionData = calculateCarbonReductions(
-                  //calculate new global carbon reduction based on new graph data
+                const {newFossilReduction, newFossilData} = calculateCarbonReductions(
+                  //calculate new global carbon budget curve based on new graph data
                   getAbbrv(selectedRegion),
                   calculationData,
                   regionalGraphData,
+                  fossilReductionData[getAbbrv(selectedRegion)],
+                  dynamicFossilData
                 )
-
-                const newFossilData = JSON.parse(
-                  JSON.stringify(dynamicFossilData), //deep copy
-                )
-                for (let i = 0; i < newRegionFossilReductionData.length; i++) {
-                  //apply new reductions to fossil data
-                  newFossilData[i + 1].value -=
-                    newRegionFossilReductionData[i].value -
-                    fossilReductionData[getAbbrv(selectedRegion)][i].value
-                }
-                //graph extrapolation to 2060
-                newFossilData[7].value =
-                  newFossilData[6].value > 30
-                    ? newFossilData[6].value * 0.82
-                    : newFossilData[6].value >= 25
-                      ? newFossilData[6].value * 0.71
-                      : newFossilData[6].value * 0.6
-                newFossilData[8].value =
-                  newFossilData[6].value > 30
-                    ? newFossilData[7].value * 0.71
-                    : newFossilData[6].value >= 25
-                      ? newFossilData[7].value * 0.58
-                      : newFossilData[7].value * 0.5
-                newFossilData[9].value =
-                  newFossilData[6].value > 30
-                    ? newFossilData[8].value * 0.542
-                    : newFossilData[6].value >= 25
-                      ? newFossilData[8].value * 0.436
-                      : newFossilData[8].value * 0.33
 
                 setDynamicFossilData(newFossilData)
 
@@ -265,7 +240,7 @@ export const BottomSheet = ({
 
                 setFossilReductionData({
                   ...fossilReductionData,
-                  [getAbbrv(selectedRegion)]: newRegionFossilReductionData,
+                  [getAbbrv(selectedRegion)]: newFossilReduction,
                 })
               }}
               onReset={() => {
@@ -295,31 +270,7 @@ export const BottomSheet = ({
                 })
                 storeData("dynamic-graph-data", JSON.stringify(newGlobalGraphData))
 
-                const newFossilData = JSON.parse(
-                  JSON.stringify(dynamicFossilData),
-                )
-                for (let i = 0; i < 6; i++) {
-                  newFossilData[i + 1].value +=
-                    fossilReductionData[getAbbrv(selectedRegion)][i].value
-                }
-                newFossilData[7].value =
-                  newFossilData[6].value > 30
-                    ? newFossilData[6].value * 0.82
-                    : newFossilData[6].value >= 25
-                      ? newFossilData[6].value * 0.71
-                      : newFossilData[6].value * 0.6
-                newFossilData[8].value =
-                  newFossilData[6].value > 30
-                    ? newFossilData[7].value * 0.71
-                    : newFossilData[6].value >= 25
-                      ? newFossilData[7].value * 0.58
-                      : newFossilData[7].value * 0.5
-                newFossilData[9].value =
-                  newFossilData[6].value > 30
-                    ? newFossilData[8].value * 0.542
-                    : newFossilData[6].value >= 25
-                      ? newFossilData[8].value * 0.436
-                      : newFossilData[7].value * 0.33
+                const newFossilData = calculateCarbonCurve(0-fossilReductionData[getAbbrv(selectedRegion)], dynamicFossilData)
 
                 setDynamicFossilData(newFossilData)
 
@@ -327,16 +278,10 @@ export const BottomSheet = ({
 
                 setFossilReductionData({
                   ...fossilReductionData,
-                  [getAbbrv(selectedRegion)]: [
-                    { year: 2025, value: 0 },
-                    { year: 2026, value: 0 },
-                    { year: 2027, value: 0 },
-                    { year: 2028, value: 0 },
-                    { year: 2029, value: 0 },
-                    { year: 2030, value: 0 },
-                  ],
+                  [getAbbrv(selectedRegion)]: 0
                 })
               }}
+
               initialGraphData={initialGraphData}
               dynamicGraphData={dynamicGraphData}
               sliderDisabled={

--- a/TECApp/app/components/DataVisualizations/CarbonBudget.tsx
+++ b/TECApp/app/components/DataVisualizations/CarbonBudget.tsx
@@ -22,10 +22,10 @@ const offset = 20
 const graphWidth = vw * 0.8
 const leftMargin = 60
 
-const dummy1Point5Limit = 100
-const dummy2Point0Limit = 148
+const dummy1Point5Limit = 50
+const dummy2Point0Limit = 70
 
-const xMin = 2024
+const xMin = 2025
 const xMax = 2060
 
 type DataPoint = {

--- a/TECApp/app/util/Calculations.tsx
+++ b/TECApp/app/util/Calculations.tsx
@@ -87,6 +87,7 @@ export const calculateCarbonReductions = (
 
     const dnv_forecast = electricity_generation.oil / (electricity_generation.oil + electricity_generation.gas)
 
+
     const additional_electricity_gen_coal = getElectricityGenerationCoal(region)
     const additional_electricity_gen_oil =
       dnv_forecast * (1 - additional_electricity_gen_coal)
@@ -100,12 +101,15 @@ export const calculateCarbonReductions = (
     const displaced_electricity_oil =
       climate_path_additional_electricity_gen * additional_electricity_gen_oil
 
+
+
     const reduction_electricity_gen_coal =
       displaced_electricity_coal / (electricity_generation.coal * 0.001)
     const reduction_electricity_gen_oil =
       displaced_electricity_oil / (electricity_generation.oil * 0.001)
     const reduction_electricity_gen_gas =
       displaced_electricity_gas / (electricity_generation.gas * 0.001)
+      
 
     const reduction_fossil_energy_coal =
       reduction_electricity_gen_coal * co2_emissions.coal
@@ -115,7 +119,7 @@ export const calculateCarbonReductions = (
       reduction_electricity_gen_gas * co2_emissions.gas
 
     const fossilReduction = reduction_fossil_energy_coal + reduction_fossil_energy_oil + reduction_fossil_energy_gas
-
+console.log(fossilReduction)
     const newFossilData = calculateCarbonCurve(fossilReduction-currFossilReduction, fossilData)
     console.log(newFossilData)
 

--- a/TECApp/app/util/Calculations.tsx
+++ b/TECApp/app/util/Calculations.tsx
@@ -129,13 +129,15 @@ console.log(fossilReduction)
 
 export const calculateCarbonCurve = (deltaFossilReduction: number, fossilData: DataPoint[]) =>{
   fossilData[1].value -= deltaFossilReduction
-  const rawValue = fossilData[1].value - (3.82+5.0-0.2)
-  fossilData[2].value = (rawValue<=26?(14.72+((rawValue-20)/6)*3.97):(18.69+((rawValue-26)/5.6)*10.71))+3.69+4.5-0.4
-  fossilData[3].value = (rawValue<=26?(12+((rawValue-20)/6)*1.25):(13.25+((rawValue-26)/5.6)*12.65))+3.63+3.8-0.6
-  fossilData[4].value = (rawValue<=26?(8.96+((rawValue-20)/6)*0.64):(9.6+((rawValue-26)/5.6)*12.5))+3.38+3.2-0.9
-  fossilData[5].value = (rawValue<=26?(6+((rawValue-20)/6)*1.31):(7.31+((rawValue-26)/5.6)*11.09))+3.05+2.5-1.3
-  fossilData[6].value = (rawValue<=26?(3.62+((rawValue-20)/6)*1.68):(5.3+((rawValue-26)/5.6)*9.7))+2.8+1.7-2.0
-  fossilData[7].value = (rawValue<=26?(2+((rawValue-20)/6)*1.56):(3.56+((rawValue-26)/5.6)*6.44))+2.5+1.2-3.0
+  //for calculations below: all numbers come from B14:I17 section of the Emission.Budget tab of TEC sheet
+  //all the ternary statements are extrapolations based on the 2030 value (also pulled from the TEC sheet)
+  const rawValue = fossilData[1].value - (3.82+5.0-0.2) 
+  fossilData[2].value = (rawValue<=26?(14.72+((rawValue-20)/6)*3.97):(18.69+((rawValue-26)/5.6)*10.71))+(3.69+4.5-0.4)
+  fossilData[3].value = (rawValue<=26?(12+((rawValue-20)/6)*1.25):(13.25+((rawValue-26)/5.6)*12.65))+(3.63+3.8-0.6)
+  fossilData[4].value = (rawValue<=26?(8.96+((rawValue-20)/6)*0.64):(9.6+((rawValue-26)/5.6)*12.5))+(3.38+3.2-0.9)
+  fossilData[5].value = (rawValue<=26?(6+((rawValue-20)/6)*1.31):(7.31+((rawValue-26)/5.6)*11.09))+(3.05+2.5-1.3)
+  fossilData[6].value = (rawValue<=26?(3.62+((rawValue-20)/6)*1.68):(5.3+((rawValue-26)/5.6)*9.7))+(2.8+1.7-2.0)
+  fossilData[7].value = (rawValue<=26?(2+((rawValue-20)/6)*1.56):(3.56+((rawValue-26)/5.6)*6.44))+(2.5+1.2-3.0)
   
   return fossilData
 }

--- a/TECApp/app/util/Calculations.tsx
+++ b/TECApp/app/util/Calculations.tsx
@@ -129,12 +129,13 @@ console.log(fossilReduction)
 
 export const calculateCarbonCurve = (deltaFossilReduction: number, fossilData: DataPoint[]) =>{
   fossilData[1].value -= deltaFossilReduction
-  fossilData[2].value = fossilData[1].value<=26?(14.72+((fossilData[1].value-20)/6)*3.97):(18.69+((fossilData[1].value-26)/5.6)*10.71)
-  fossilData[3].value = fossilData[1].value<=26?(12+((fossilData[1].value-20)/6)*1.25):(13.25+((fossilData[1].value-26)/5.6)*12.65)
-  fossilData[4].value = fossilData[1].value<=26?(8.96+((fossilData[1].value-20)/6)*0.64):(9.6+((fossilData[1].value-26)/5.6)*12.5)
-  fossilData[5].value = fossilData[1].value<=26?(6+((fossilData[1].value-20)/6)*1.31):(7.31+((fossilData[1].value-26)/5.6)*11.09)
-  fossilData[6].value = fossilData[1].value<=26?(3.62+((fossilData[1].value-20)/6)*1.68):(5.3+((fossilData[1].value-26)/5.6)*9.7)
-  fossilData[7].value = fossilData[1].value<=26?(2+((fossilData[1].value-20)/6)*1.56):(3.56+((fossilData[1].value-26)/5.6)*6.44)
+  const rawValue = fossilData[1].value - (3.82+5.0-0.2)
+  fossilData[2].value = (rawValue<=26?(14.72+((rawValue-20)/6)*3.97):(18.69+((rawValue-26)/5.6)*10.71))+3.69+4.5-0.4
+  fossilData[3].value = (rawValue<=26?(12+((rawValue-20)/6)*1.25):(13.25+((rawValue-26)/5.6)*12.65))+3.63+3.8-0.6
+  fossilData[4].value = (rawValue<=26?(8.96+((rawValue-20)/6)*0.64):(9.6+((rawValue-26)/5.6)*12.5))+3.38+3.2-0.9
+  fossilData[5].value = (rawValue<=26?(6+((rawValue-20)/6)*1.31):(7.31+((rawValue-26)/5.6)*11.09))+3.05+2.5-1.3
+  fossilData[6].value = (rawValue<=26?(3.62+((rawValue-20)/6)*1.68):(5.3+((rawValue-26)/5.6)*9.7))+2.8+1.7-2.0
+  fossilData[7].value = (rawValue<=26?(2+((rawValue-20)/6)*1.56):(3.56+((rawValue-26)/5.6)*6.44))+2.5+1.2-3.0
   
   return fossilData
 }

--- a/TECApp/eas.json
+++ b/TECApp/eas.json
@@ -5,16 +5,16 @@
   "build": {
     "development": {
       "developmentClient": true,
-      "distribution": "internal"
+      "distribution": "internal",
+      "channel": "development"
     },
     "preview": {
       "distribution": "internal",
-      "ios":{
-        "simulator": true
-      }
-
+      "channel": "preview"
     },
-    "production": {}
+    "production": {
+      "channel": "production"
+    }
   },
   "submit": {
     "production": {}

--- a/TECApp/package-lock.json
+++ b/TECApp/package-lock.json
@@ -28,6 +28,7 @@
         "expo-router": "~3.5.23",
         "expo-splash-screen": "^0.27.5",
         "expo-status-bar": "~1.12.1",
+        "expo-updates": "^0.25.24",
         "fast-xml-parser": "^4.4.1",
         "firebase": "^10.12.0",
         "react": "18.2.0",
@@ -2793,6 +2794,99 @@
       }
     },
     "node_modules/@expo/env/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@expo/fingerprint": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@expo/fingerprint/-/fingerprint-0.10.3.tgz",
+      "integrity": "sha512-h/BnnyloJyMSrzeXonKLE6HfiMpRg3e9m8CAv+eUaAozG9heKMG9ftHW4cfm2StDYj/rWjFc5YK6MSIX6qd+xg==",
+      "dependencies": {
+        "@expo/spawn-async": "^1.7.2",
+        "chalk": "^4.1.2",
+        "debug": "^4.3.4",
+        "find-up": "^5.0.0",
+        "minimatch": "^3.0.4",
+        "p-limit": "^3.1.0",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.6.0"
+      },
+      "bin": {
+        "fingerprint": "bin/cli.js"
+      }
+    },
+    "node_modules/@expo/fingerprint/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@expo/fingerprint/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@expo/fingerprint/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@expo/fingerprint/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/@expo/fingerprint/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@expo/fingerprint/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@expo/fingerprint/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
@@ -10989,6 +11083,11 @@
         "expo": "*"
       }
     },
+    "node_modules/expo-eas-client": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/expo-eas-client/-/expo-eas-client-0.12.0.tgz",
+      "integrity": "sha512-Jkww9Cwpv0z7DdLYiRX0r4fqBEcI9cKqTn7cHx63S09JaZ2rcwEE4zYHgrXwjahO+tU2VW8zqH+AJl6RhhW4zA=="
+    },
     "node_modules/expo-file-system": {
       "version": "17.0.1",
       "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-17.0.1.tgz",
@@ -11008,6 +11107,11 @@
         "expo": "*"
       }
     },
+    "node_modules/expo-json-utils": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/expo-json-utils/-/expo-json-utils-0.13.1.tgz",
+      "integrity": "sha512-mlfaSArGVb+oJmUcR22jEONlgPp0wj4iNIHfQ2je9Q8WTOqMc0Ws9tUciz3JdJnhffdHqo/k8fpvf0IRmN5HPA=="
+    },
     "node_modules/expo-keep-awake": {
       "version": "13.0.2",
       "resolved": "https://registry.npmjs.org/expo-keep-awake/-/expo-keep-awake-13.0.2.tgz",
@@ -11023,6 +11127,18 @@
       "dependencies": {
         "expo-constants": "~16.0.0",
         "invariant": "^2.2.4"
+      }
+    },
+    "node_modules/expo-manifests": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/expo-manifests/-/expo-manifests-0.14.3.tgz",
+      "integrity": "sha512-L3b5/qocBPiQjbW0cpOHfnqdKZbTJS7sA3mgeDJT+mWga/xYsdpma1EfNmsuvrOzjLGjStr1k1fceM9Bl49aqQ==",
+      "dependencies": {
+        "@expo/config": "~9.0.0",
+        "expo-json-utils": "~0.13.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-modules-autolinking": {
@@ -11285,6 +11401,116 @@
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/expo-status-bar/-/expo-status-bar-1.12.1.tgz",
       "integrity": "sha512-/t3xdbS8KB0prj5KG5w7z+wZPFlPtkgs95BsmrP/E7Q0xHXTcDcQ6Cu2FkFuRM+PKTb17cJDnLkawyS5vDLxMA=="
+    },
+    "node_modules/expo-structured-headers": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/expo-structured-headers/-/expo-structured-headers-3.8.0.tgz",
+      "integrity": "sha512-R+gFGn0x5CWl4OVlk2j1bJTJIz4KO8mPoCHpRHmfqMjmrMvrOM0qQSY3V5NHXwp1yT/L2v8aUmFQsBRIdvi1XA=="
+    },
+    "node_modules/expo-updates": {
+      "version": "0.25.24",
+      "resolved": "https://registry.npmjs.org/expo-updates/-/expo-updates-0.25.24.tgz",
+      "integrity": "sha512-juqdOUvaMfu6zeUg3fTk6ciLw4QK+0HXNR0+X41BVOFilNmlTFQZ6LyRGJAZJP7HQs2bHR5d/btAXkejtIqVXw==",
+      "dependencies": {
+        "@expo/code-signing-certificates": "0.0.5",
+        "@expo/config": "~9.0.0-beta.0",
+        "@expo/config-plugins": "~8.0.8",
+        "@expo/fingerprint": "^0.10.2",
+        "@expo/spawn-async": "^1.7.2",
+        "arg": "4.1.0",
+        "chalk": "^4.1.2",
+        "expo-eas-client": "~0.12.0",
+        "expo-manifests": "~0.14.0",
+        "expo-structured-headers": "~3.8.0",
+        "expo-updates-interface": "~0.16.2",
+        "fast-glob": "^3.3.2",
+        "fbemitter": "^3.0.0",
+        "ignore": "^5.3.1",
+        "resolve-from": "^5.0.0"
+      },
+      "bin": {
+        "expo-updates": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-updates-interface": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/expo-updates-interface/-/expo-updates-interface-0.16.2.tgz",
+      "integrity": "sha512-929XBU70q5ELxkKADj1xL0UIm3HvhYhNAOZv5DSk7rrKvLo7QDdPyl+JVnwZm9LrkNbH4wuE2rLoKu1KMgZ+9A==",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-updates/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/expo-updates/node_modules/arg": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.0.tgz",
+      "integrity": "sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg=="
+    },
+    "node_modules/expo-updates/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/expo-updates/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/expo-updates/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/expo-updates/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/expo-updates/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/exponential-backoff": {
       "version": "3.1.1",

--- a/TECApp/package.json
+++ b/TECApp/package.json
@@ -17,6 +17,7 @@
     "@gorhom/bottom-sheet": "^4.6.3",
     "@miblanchard/react-native-slider": "^2.6.0",
     "@openspacelabs/react-native-zoomable-view": "^2.1.6",
+    "@react-native-async-storage/async-storage": "1.23.1",
     "@react-native-community/slider": "^4.5.2",
     "@react-native-picker/picker": "2.7.5",
     "@react-navigation/native": "^6.1.17",
@@ -30,6 +31,7 @@
     "expo-router": "~3.5.23",
     "expo-splash-screen": "^0.27.5",
     "expo-status-bar": "~1.12.1",
+    "expo-updates": "^0.25.24",
     "fast-xml-parser": "^4.4.1",
     "firebase": "^10.12.0",
     "react": "18.2.0",
@@ -43,8 +45,7 @@
     "react-native-svg-pan-zoom": "^0.1.2",
     "react-native-web": "^0.19.11",
     "react-router-dom": "^6.22.3",
-    "typescript": "~5.3.3",
-    "@react-native-async-storage/async-storage": "1.23.1"
+    "typescript": "~5.3.3"
   },
   "devDependencies": {
     "@babel/core": "^7.24.5",

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -3,7 +3,7 @@ import "dotenv/config"
 import { getAllDefaultValues, getMinMaxValues } from "./src/AllocationDefaults"
 import Pool from "pg"
 import cors from "cors"
-import { getInitialFossilData, getInitialGraphData, getRegionCalculationData } from "./src/GraphData"
+import { getInitialGraphData, getRegionCalculationData } from "./src/GraphData"
 
 const app = express()
 const port = process.env.LOCAL_PORT
@@ -35,8 +35,6 @@ router.get('/minmax', getMinMaxValues)
 router.get('/initgraph', getInitialGraphData)
 
 router.get('/calc/:region', getRegionCalculationData)
-
-router.get('/fossil-emissions', getInitialFossilData)
 
 app.listen(port, () => {
   console.log(`App running on port ${port}.`)

--- a/backend/src/GraphData.ts
+++ b/backend/src/GraphData.ts
@@ -34,7 +34,6 @@ type InitialGraphData = {
 const regions = ["global","chn","ind","mea","nam","nee","sea","eur","lam","ssa","opa"]
 
 export const getInitialGraphData = async (req: Request, res: Response, next: NextFunction) => {
-    console.log("log")
 
     let results = {global:{}, chn:{},ind: {}, mea:{}, nam:{}, nee:{}, sea:{}, eur:{}, lam:{}, ssa:{}, opa:{}} as InitialGraphData
 
@@ -169,7 +168,7 @@ export const getRegionCalculationData = async (req: Request, res: Response, next
     }
 
     //co2 emissions
-    const co2_emissions_query = await pool.query("SELECT * FROM transpose_co2_emissions WHERE region=$1 AND year>=203-0 AND (energy_type='coal' OR energy_type='natural_gas' OR energy_type='oil')", [region])
+    const co2_emissions_query = await pool.query("SELECT * FROM transpose_co2_emissions WHERE region=$1 AND year=2030 AND (energy_type='coal' OR energy_type='natural_gas' OR energy_type='oil')", [region])
     for(let i = 0; i<co2_emissions_query.rows.length; i++){
         const nonrenewableKey = nonrenewables[i] as keyof typeof results.co2_emissions
         results.co2_emissions[nonrenewableKey] = parseFloat(co2_emissions_query.rows[i].value)


### PR DESCRIPTION
Changed how calculations are done for the carbon budget graph based on Monday's meeting; basically calculating only for 2030 then doing extrapolation until 2060 instead of calculating for all values 2025-2030. 

I also changed some stuff with the app setup and verified that the IOS build works with the developer account! If you're curious and want to download the build onto your iPhone, let me know because I'll need to add your device to the eas allowed device list first. Hoping to try and get this current version draft onto the actual app store before next Monday.

<img width="363" alt="Screenshot 2024-09-11 at 11 37 10 PM" src="https://github.com/user-attachments/assets/00637532-40c5-4cee-8d3a-5b9743a8f991">

